### PR TITLE
fix!: switch posts pagination to cursor and rename to `next`

### DIFF
--- a/features/api/me_notes.feature
+++ b/features/api/me_notes.feature
@@ -9,7 +9,7 @@ Feature: Own notes endpoint
     When I send GET /api/v1/me/notes
     Then the response status code is 200
     And the response list "items" has 20 items
-    And the response field "next_cursor" is not null
+    And the response field "next" is not null
 
   Scenario: Authentication failure returns 401
     Given a valid gateway token "test-token" and publication URL "https://example.substack.com"

--- a/features/api/me_posts.feature
+++ b/features/api/me_posts.feature
@@ -44,7 +44,3 @@ Feature: Own posts endpoint
     When I send GET /api/v1/me/posts?limit=101
     Then the response status code is 422
 
-  Scenario: negative offset is rejected with 422
-    Given a valid gateway token "test-token" and publication URL "https://example.substack.com"
-    When I send GET /api/v1/me/posts?offset=-1
-    Then the response status code is 422

--- a/features/api/profile_notes.feature
+++ b/features/api/profile_notes.feature
@@ -10,7 +10,7 @@ Feature: Profile notes endpoint
     When I send GET /api/v1/profiles/jakubslys/notes
     Then the response status code is 200
     And the response list "items" has 12 items
-    And the response field "next_cursor" is not null
+    And the response field "next" is not null
 
   Scenario: Profile not found returns 404
     Given a valid gateway token "test-token" and publication URL "https://example.substack.com"

--- a/src/gateway_oss/api/v1/me.py
+++ b/src/gateway_oss/api/v1/me.py
@@ -10,7 +10,7 @@ from gateway_oss.api.deps import (
     get_posts_service,
     get_profiles_service,
 )
-from gateway_oss.models.pagination import CursorPage, OffsetPage
+from gateway_oss.models.pagination import CursorLimitPage, CursorPage
 from gateway_oss.models.schemas import (
     FollowingResponse,
     NotesPageResponse,
@@ -48,12 +48,12 @@ async def get_me_notes(
 async def get_me_posts(
     profiles: Annotated[ProfilesService, Depends(get_profiles_service)],
     posts: Annotated[PostsService, Depends(get_posts_service)],
-    page: Annotated[OffsetPage, Depends()],
+    page: Annotated[CursorLimitPage, Depends()],
 ) -> PostsPageResponse:
     """Return a page of the authenticated user's own posts."""
     profile = await profiles.get_own_profile()
     result = await posts.get_posts_for_profile(
-        profile.id, limit=page.limit, offset=page.offset
+        profile.id, limit=page.limit, cursor=page.cursor
     )
     return PostsPageResponse.from_substack(result)
 

--- a/src/gateway_oss/api/v1/profiles.py
+++ b/src/gateway_oss/api/v1/profiles.py
@@ -5,7 +5,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends
 
 from gateway_oss.api.deps import get_posts_service, get_profiles_service
-from gateway_oss.models.pagination import CursorPage, OffsetPage
+from gateway_oss.models.pagination import CursorLimitPage, CursorPage
 from gateway_oss.models.schemas import (
     NotesPageResponse,
     PostsPageResponse,
@@ -32,12 +32,12 @@ async def get_profile_posts(
     slug: str,
     profiles: Annotated[ProfilesService, Depends(get_profiles_service)],
     posts: Annotated[PostsService, Depends(get_posts_service)],
-    page: Annotated[OffsetPage, Depends()],
+    page: Annotated[CursorLimitPage, Depends()],
 ) -> PostsPageResponse:
     """Return a page of posts for the given profile slug."""
     profile_id = await profiles.get_profile_id_by_slug(slug)
     result = await posts.get_posts_for_profile(
-        profile_id, limit=page.limit, offset=page.offset
+        profile_id, limit=page.limit, cursor=page.cursor
     )
     return PostsPageResponse.from_substack(result)
 

--- a/src/gateway_oss/mcp/app.py
+++ b/src/gateway_oss/mcp/app.py
@@ -140,13 +140,13 @@ async def get_my_notes(
 async def get_my_posts(
     token: str,
     limit: int = 25,
-    offset: int = 0,
+    cursor: str | None = None,
 ) -> dict[str, Any]:
     async with _authenticated_clients(token) as (publication, substack):
         profiles = ProfilesService(substack)
         posts = PostsService(publication, substack)
         profile = await profiles.get_own_profile()
-        page = await posts.get_posts_for_profile(profile.id, limit=limit, offset=offset)
+        page = await posts.get_posts_for_profile(profile.id, limit=limit, cursor=cursor)
     return PostsPageResponse.from_substack(page).model_dump()
 
 
@@ -244,7 +244,7 @@ async def get_profile(
 async def get_profile_posts(
     slug: str,
     limit: int = 25,
-    offset: int = 0,
+    cursor: str | None = None,
 ) -> dict[str, Any]:
     async with (
         _public_publication_client() as publication,
@@ -253,7 +253,7 @@ async def get_profile_posts(
         profiles = ProfilesService(substack)
         posts = PostsService(publication, substack)
         profile_id = await profiles.get_profile_id_by_slug(slug)
-        page = await posts.get_posts_for_profile(profile_id, limit=limit, offset=offset)
+        page = await posts.get_posts_for_profile(profile_id, limit=limit, cursor=cursor)
     return PostsPageResponse.from_substack(page).model_dump()
 
 

--- a/src/gateway_oss/models/pagination.py
+++ b/src/gateway_oss/models/pagination.py
@@ -14,3 +14,10 @@ class CursorPage(BaseModel):
     """Shared dependency for cursor-paginated endpoints."""
 
     cursor: str | None = None
+
+
+class CursorLimitPage(BaseModel):
+    """Shared dependency for cursor-paginated endpoints with a page-size limit."""
+
+    cursor: str | None = None
+    limit: int = Field(default=25, gt=0, le=100)

--- a/src/gateway_oss/models/schemas.py
+++ b/src/gateway_oss/models/schemas.py
@@ -109,13 +109,13 @@ class NoteResponse(BaseModel):
 
 class NotesPageResponse(BaseModel):
     items: list[NoteResponse]
-    next_cursor: str | None = None
+    next: str | None = None
 
     @classmethod
     def from_substack(cls, page: SubstackNotesPage) -> NotesPageResponse:
         return cls(
             items=[NoteResponse.from_substack(n) for n in page.items],
-            next_cursor=page.next_cursor,
+            next=page.next_cursor,
         )
 
 
@@ -144,13 +144,13 @@ class PostResponse(BaseModel):
 
 class PostsPageResponse(BaseModel):
     items: list[PostResponse]
-    next_cursor: str | None = None
+    next: str | None = None
 
     @classmethod
     def from_substack(cls, page: SubstackProfilePostsPage) -> PostsPageResponse:
         return cls(
             items=[PostResponse.from_substack(p) for p in page.posts],
-            next_cursor=page.next_cursor,
+            next=page.next_cursor,
         )
 
 

--- a/src/gateway_oss/services/posts.py
+++ b/src/gateway_oss/services/posts.py
@@ -22,16 +22,24 @@ class PostsService:
         self._sub = sub
 
     async def get_posts_for_profile(
-        self, profile_id: int, limit: int = 25, offset: int = 0
+        self,
+        profile_id: int,
+        limit: int = 25,
+        cursor: str | None = None,
     ) -> SubstackProfilePostsPage:
         """GET /profile/posts — posts for a given profile ID."""
         _log.debug(
-            "Fetching posts for profile_id=%d (limit=%d, offset=%d)",
+            "Fetching posts for profile_id=%d (limit=%d, cursor=%r)",
             profile_id,
             limit,
-            offset,
+            cursor,
         )
-        params = {"profile_user_id": profile_id, "limit": limit, "offset": offset}
+        params: dict[str, str | int] = {
+            "profile_user_id": profile_id,
+            "limit": limit,
+        }
+        if cursor:
+            params["cursor"] = cursor
         r = await self._sub.get("profile/posts", params=params)
         page = SubstackProfilePostsPage.model_validate(r.json())
         _log.debug(


### PR DESCRIPTION
## Summary
- Substack's `profile/posts` endpoint now rejects the `offset` query parameter outright (`400 Invalid value` for any value, including `0`), so `/api/v1/me/posts` and `/api/v1/profiles/{slug}/posts` were returning 502.
- Move both routes and the matching MCP tools (`get_my_posts`, `get_profile_posts`, plus `PostsService.get_posts_for_profile`) to cursor-based pagination using Substack's `nextCursor`.
- Rename the outward page-response field across `NotesPageResponse` and `PostsPageResponse` from `next_cursor` to `next` for a tighter, consistent surface.

## Breaking changes
- `/api/v1/me/posts` and `/api/v1/profiles/{slug}/posts` no longer accept `offset`; pass `cursor` instead. `limit` still supported.
- `NotesPageResponse` / `PostsPageResponse` expose `next` instead of `next_cursor` (REST + MCP).
- MCP tools `get_my_posts` / `get_profile_posts` take `cursor` instead of `offset`.

## Test plan
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run ty check .`
- [x] `uv build`
- [x] `uv run pytest tests/` (37 passed)
- [x] `uv run behave features/` (113 scenarios passed)
- [x] `uv run behave e2e` against live Substack with real token (16/16 passed, incl. previously-failing `me/posts` and `profiles/{slug}/posts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)