### PR TITLE
ci: migrate Dependabot auto-merge to fastify action

### DIFF
--- a/.github/workflows/auto-approve-dependabot.yaml
+++ b/.github/workflows/auto-approve-dependabot.yaml
@@ -6,34 +6,10 @@ permissions:
     pull-requests: write
 
 jobs:
-    auto-approve:
-        name: Approve PR
-        runs-on: ubuntu-latest
-        if: github.actor == 'dependabot[bot]'
-        steps:
-            - name: Mint a GitHub App installation token
-              uses: actions/create-github-app-token@v3
-              id: app-token
-              with:
-                  client-id: ${{ secrets.CLIENT_ID }}
-                  private-key: ${{ secrets.APP_PRIVATE_KEY }}
-            - name: Dependabot metadata
-              id: metadata
-              uses: dependabot/fetch-metadata@v3
-              with:
-                  github-token: ${{ secrets.GITHUB_TOKEN }}
-            - name: Approve a PR
-              run: gh pr review --approve "$PR_URL"
-              env:
-                  PR_URL: ${{ github.event.pull_request.html_url }}
-                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
-
     auto-merge:
-        name: Merge PR
-        needs:
-            - auto-approve
+        name: Approve and merge PR
         runs-on: ubuntu-latest
-        if: github.actor == 'dependabot[bot]'
+        if: github.event.pull_request.user.login == 'dependabot[bot]'
         steps:
             - name: Mint a GitHub App installation token
               uses: actions/create-github-app-token@v3
@@ -41,13 +17,9 @@ jobs:
               with:
                   client-id: ${{ secrets.CLIENT_ID }}
                   private-key: ${{ secrets.APP_PRIVATE_KEY }}
-            - name: Dependabot metadata
-              id: metadata
-              uses: dependabot/fetch-metadata@v3
+            - name: Approve and enable auto-merge
+              uses: fastify/github-action-merge-dependabot@v3
               with:
-                  github-token: ${{ secrets.GITHUB_TOKEN }}
-            - name: Enable auto-merge for Dependabot PRs
-              run: gh pr merge --auto --squash "$PR_URL"
-              env:
-                  PR_URL: ${{ github.event.pull_request.html_url }}
-                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
+                  github-token: ${{ steps.app-token.outputs.token }}
+                  merge-method: merge
+                  use-github-auto-merge: true


### PR DESCRIPTION
## What

Replace the hand-rolled two-job approve+merge workflow with [`fastify/github-action-merge-dependabot@v3`](https://github.com/fastify/github-action-merge-dependabot).

## Changes

- Collapse the `auto-approve` + `auto-merge` jobs into a single approve-and-merge step.
- Use `merge-method: merge` and `use-github-auto-merge: true` (keeps waiting on required CI checks before merging).
- Drop the unused `dependabot/fetch-metadata` steps.
- Tighten the actor guard from `github.actor` to `github.event.pull_request.user.login`.
- Keep the GitHub App token (`create-github-app-token`) so approvals/merges re-trigger required CI.

## Note

`use-github-auto-merge: true` requires "Allow auto-merge" enabled on the repo plus branch protection with required checks on the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)