### PR TITLE
fix: build MCP ASGI app lazily to break extension import cycle

### DIFF
--- a/packages/gateway_oss/src/gateway_oss/mcp/app.py
+++ b/packages/gateway_oss/src/gateway_oss/mcp/app.py
@@ -362,8 +362,23 @@ def register_authenticated_tools(mcp: FastMCP) -> None:
     )(get_post_comments)
 
 
-for extension in runtime.extensions:
-    extension.register_mcp(_mcp, runtime.context)
+_mcp_app: Any = None
 
 
-mcp = _mcp.http_app(transport="streamable-http", path="/", stateless_http=True)
+def _build_mcp_app() -> Any:
+    for extension in runtime.extensions:
+        extension.register_mcp(_mcp, runtime.context)
+    return _mcp.http_app(transport="streamable-http", path="/", stateless_http=True)
+
+
+def __getattr__(name: str) -> Any:
+    # Build the MCP ASGI app lazily: extension registration must not run at
+    # import time. An extension's register_mcp imports gateway_pro.mcp.app,
+    # which imports this module back — doing that during import would re-enter
+    # a partially-initialised module and raise a circular ImportError.
+    if name == "mcp":
+        global _mcp_app
+        if _mcp_app is None:
+            _mcp_app = _build_mcp_app()
+        return _mcp_app
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Problem

`gateway_oss.mcp.app` registered extensions and built the ASGI app **at module-import time** (module-level `for extension in runtime.extensions: extension.register_mcp(...)` + `mcp = _mcp.http_app(...)`).

A pro extension's `register_mcp` imports `gateway_pro.mcp.app`, which imports `gateway_oss.mcp.app` back. So importing `gateway_pro.mcp.app` **standalone** (e.g. a unit test) re-entered this partially-initialised module and raised a circular `ImportError`. Downstream this forced a test workaround: an env-var to disable extensions plus `sys.modules` eviction and an lru_cache clear.

## Fix

Move the extension-registration loop and `http_app` construction behind a lazy module `__getattr__` for `mcp`:

- Importing `gateway_oss.mcp.app` now has **no side effects**.
- The app is built (and cached) on first access to `mcp`, by which point every module is fully initialised.
- Public tool decorators (`@_mcp.tool`) stay at import time — they never import extensions and never triggered the cycle.
- Consumers (`app_factory.py`, `__init__.py`) still `from gateway_oss.mcp.app import mcp`; PEP 562 routes that through `__getattr__` unchanged.

Importing `gateway_pro.mcp.app` standalone now works with no workaround. The companion cleanup (dropping the env-var / `sys.modules` dance from the pro test) lands in gateway-pro once this ships in a release and `OSS_REF` is bumped.

## Verification

- `pytest` (oss + pro): 193 passed
- `ruff check`: clean
- `ty check`: clean
- `behave`: 176 scenarios / 27 features passed
- Smoke: `import gateway_pro.mcp.app` standalone succeeds; `gateway_oss.mcp.app.mcp` builds lazily and is cached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)