### PR TITLE
ci: add force input to the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,17 @@
 name: Make a new release
 on:
   workflow_dispatch:
+    inputs:
+      force:
+        description: "Force a version bump level (auto = let commit analysis decide)"
+        type: choice
+        default: auto
+        options:
+          - auto
+          - patch
+          - minor
+          - major
+          - prerelease
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -45,6 +56,7 @@ jobs:
         id: semantic
         with:
           github_token: ${{ steps.app-token.outputs.token }}
+          force: ${{ inputs.force != 'auto' && inputs.force || '' }}
 
       - name: Build package
         if: steps.semantic.outputs.released == 'true'


### PR DESCRIPTION
Adds an optional `force` (workflow_dispatch) input to the release workflow so a release can be cut with an explicit bump level (patch/minor/major/prerelease). Needed to release a main whose only new commits are `refactor:`/`chore:` (which the default commit analysis treats as no-release). Defaults to `auto` — commit-analysis, i.e. current behavior — so nothing changes for normal releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)