### PR TITLE
feat: relocate application assembly into the shell package

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ different interfaces.
 - **REST API** at `/api/v1/*`
 - **MCP server** at `/mcp`
 
-Both share the same service layer and HTTP clients.
+Both share the same service layer and HTTP clients. The thin
+`substack_gateway` shell package assembles the application (REST + MCP
+composition), while `gateway_oss` provides the OSS module surface as a facade.
 
 ## Quickstart
 


### PR DESCRIPTION
Cuts a release covering the app-assembly relocation already on `main` (`gateway_oss` reduced to a facade; composition moved to the shell `substack_gateway`). Contains one real, minimal change — a README architecture note — so semantic-release detects a `feat` and cuts a minor release. The empty-commit attempt (#84) landed no distinct commit, so no release was produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)