### PR TITLE
feat: note engagement (like, unlike, reply, list replies)

### DIFF
--- a/packages/gateway_core/src/gateway_core/models/substack.py
+++ b/packages/gateway_core/src/gateway_core/models/substack.py
@@ -216,3 +216,47 @@ class SubstackUserSettingsResponse(BaseModel):
 
     user_settings: list[SubstackUserSetting]
     qualifies_for_badge: bool | None = None
+
+
+# ------------------------------------------------------------------
+# Rich comment shape (note threads / replies)
+# ------------------------------------------------------------------
+
+
+class SubstackPostComment(BaseModel):
+    id: int
+    body: str
+    post_id: int | None = None
+    user_id: int | None = None
+    publication_id: int | None = None
+    date: str | None = None
+    deleted: bool = False
+    name: str | None = None
+    photo_url: str | None = None
+    ancestor_path: str | None = None
+    type: str | None = None
+    status: str | None = None
+    reaction_count: int | None = None
+
+    @property
+    def parent_id(self) -> int | None:
+        path = self.ancestor_path or ""
+        if not path:
+            return None
+        last = path.split(".")[-1]
+        try:
+            return int(last)
+        except ValueError:
+            return None
+
+
+class SubstackCommentBranch(BaseModel):
+    comment: SubstackPostComment
+
+
+class SubstackCommentBranchesResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    branches: list[SubstackCommentBranch] = Field(
+        alias="commentBranches", default_factory=list
+    )

--- a/packages/gateway_notes/src/gateway_notes/schemas.py
+++ b/packages/gateway_notes/src/gateway_notes/schemas.py
@@ -8,6 +8,7 @@ from gateway_core.models.substack import (
     SubstackNote,
     SubstackNoteCreated,
     SubstackNotesPage,
+    SubstackPostComment,
 )
 
 _log = logging.getLogger(__name__)
@@ -82,3 +83,45 @@ class CreateNoteResponse(BaseModel):
     @classmethod
     def from_substack(cls, note: SubstackNoteCreated) -> CreateNoteResponse:
         return cls(id=note.id)
+
+
+class NoteReplyCreatedResponse(BaseModel):
+    id: int
+    date: str | None = None
+    status: str | None = None
+
+    @classmethod
+    def from_substack(cls, note: SubstackNoteCreated) -> NoteReplyCreatedResponse:
+        return cls(id=note.id, date=note.date, status=note.status)
+
+
+class NoteReplyItem(BaseModel):
+    id: int
+    body: str
+    parent_id: int | None = None
+    user_id: int | None = None
+    date: str | None = None
+    deleted: bool = False
+    author_name: str | None = None
+    reaction_count: int | None = None
+
+    @classmethod
+    def from_substack(cls, c: SubstackPostComment) -> NoteReplyItem:
+        return cls(
+            id=c.id,
+            body=c.body,
+            parent_id=c.parent_id,
+            user_id=c.user_id,
+            date=c.date,
+            deleted=c.deleted,
+            author_name=c.name,
+            reaction_count=c.reaction_count,
+        )
+
+
+class NoteRepliesResponse(BaseModel):
+    items: list[NoteReplyItem]
+
+    @classmethod
+    def from_substack(cls, replies: list[SubstackPostComment]) -> NoteRepliesResponse:
+        return cls(items=[NoteReplyItem.from_substack(c) for c in replies])

--- a/packages/gateway_notes/src/gateway_notes/service.py
+++ b/packages/gateway_notes/src/gateway_notes/service.py
@@ -7,13 +7,18 @@ from gateway_core.client.substack import SubstackClient
 from gateway_core.converters.markdown import markdown_to_note_payload
 from gateway_core.models.substack import (
     SubstackAttachmentCreated,
+    SubstackCommentBranchesResponse,
     SubstackItemResponse,
     SubstackNote,
     SubstackNoteCreated,
     SubstackNotesPage,
+    SubstackPostComment,
 )
 
 _log = logging.getLogger(__name__)
+
+_LIKE_REACTION = "❤"
+_FOR_YOU_TAB_ID = "for-you"
 
 
 class NotesService:
@@ -87,3 +92,40 @@ class NotesService:
     async def _get_reader_comment(self, comment_id: int) -> SubstackNote:
         r = await self._pub.get(f"reader/comment/{comment_id}")
         return SubstackItemResponse.model_validate(r.json()).item
+
+    async def like_note(self, note_id: int) -> None:
+        """POST /comment/{id}/reaction — add a heart reaction to a note."""
+        _log.debug("Adding like to note id=%d", note_id)
+        await self._sub.post(
+            f"comment/{note_id}/reaction",
+            json={"publication_id": None, "reaction": _LIKE_REACTION},
+        )
+
+    async def unlike_note(self, note_id: int) -> None:
+        """DELETE /comment/{id}/reaction — remove the heart reaction from a note."""
+        _log.debug("Removing like from note id=%d", note_id)
+        await self._sub.delete(
+            f"comment/{note_id}/reaction",
+            json={
+                "publication_id": None,
+                "reaction": _LIKE_REACTION,
+                "tabId": _FOR_YOU_TAB_ID,
+            },
+        )
+
+    async def reply_to_note(self, parent_id: int, body: str) -> SubstackNoteCreated:
+        """POST /comment/feed/ with parent_id — reply to a note or note-comment."""
+        _log.debug("Replying to note parent_id=%d", parent_id)
+        payload = markdown_to_note_payload(body)
+        payload["parent_id"] = parent_id
+        r = await self._sub.post("comment/feed/", json=payload)
+        created = SubstackNoteCreated.model_validate(r.json())
+        _log.debug("Created reply id=%d to parent_id=%d", created.id, parent_id)
+        return created
+
+    async def list_note_replies(self, parent_id: int) -> list[SubstackPostComment]:
+        """GET /reader/comment/{id}/replies — direct replies in a note thread."""
+        _log.debug("Listing replies to parent_id=%d", parent_id)
+        r = await self._sub.get(f"reader/comment/{parent_id}/replies")
+        page = SubstackCommentBranchesResponse.model_validate(r.json())
+        return [b.comment for b in page.branches]

--- a/packages/gateway_notes/tests/test_note_comments.py
+++ b/packages/gateway_notes/tests/test_note_comments.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock
 import httpx
 import pytest
 
+from gateway_core.models.substack import SubstackPostComment
 from gateway_notes.service import NotesService
 
 
@@ -45,3 +46,10 @@ async def test_list_note_replies_flattens_comment_branches() -> None:
     sub.get.assert_awaited_once_with("reader/comment/131648795/replies")
     assert [r.id for r in replies] == [1, 2]
     assert [r.body for r in replies] == ["first", "second"]
+
+
+def test_post_comment_parent_id_parses_ancestor_path() -> None:
+    assert SubstackPostComment(id=1, body="x", ancestor_path="1.2.3").parent_id == 3
+    assert SubstackPostComment(id=1, body="x").parent_id is None
+    assert SubstackPostComment(id=1, body="x", ancestor_path="").parent_id is None
+    assert SubstackPostComment(id=1, body="x", ancestor_path="1.2.x").parent_id is None

--- a/packages/gateway_notes/tests/test_note_comments.py
+++ b/packages/gateway_notes/tests/test_note_comments.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from gateway_notes.service import NotesService
+
+
+def _resp(json: object) -> httpx.Response:
+    return httpx.Response(200, json=json, request=httpx.Request("GET", "http://test"))
+
+
+@pytest.mark.anyio
+async def test_reply_to_note_posts_to_comment_feed_with_parent_id() -> None:
+    sub = AsyncMock()
+    sub.post.return_value = _resp({"id": 999, "date": "2026-08-04", "status": "ok"})
+    service = NotesService(AsyncMock(), sub)
+
+    created = await service.reply_to_note(parent_id=234058408, body="hello")
+
+    assert created.id == 999
+    sub.post.assert_awaited_once()
+    call = sub.post.await_args
+    assert call.args[0] == "comment/feed/"
+    assert call.kwargs["json"]["parent_id"] == 234058408
+
+
+@pytest.mark.anyio
+async def test_list_note_replies_flattens_comment_branches() -> None:
+    sub = AsyncMock()
+    sub.get.return_value = _resp(
+        {
+            "commentBranches": [
+                {"comment": {"id": 1, "body": "first"}},
+                {"comment": {"id": 2, "body": "second"}},
+            ]
+        }
+    )
+    service = NotesService(AsyncMock(), sub)
+
+    replies = await service.list_note_replies(131648795)
+
+    sub.get.assert_awaited_once_with("reader/comment/131648795/replies")
+    assert [r.id for r in replies] == [1, 2]
+    assert [r.body for r in replies] == ["first", "second"]

--- a/packages/gateway_notes/tests/test_note_reactions.py
+++ b/packages/gateway_notes/tests/test_note_reactions.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway_notes.service import NotesService
+
+
+@pytest.mark.anyio
+async def test_like_note_posts_heart_reaction() -> None:
+    sub = AsyncMock()
+    service = NotesService(AsyncMock(), sub)
+
+    await service.like_note(234058408)
+
+    sub.post.assert_awaited_once_with(
+        "comment/234058408/reaction",
+        json={"publication_id": None, "reaction": "❤"},
+    )
+
+
+@pytest.mark.anyio
+async def test_unlike_note_deletes_heart_reaction_with_tab_id() -> None:
+    sub = AsyncMock()
+    service = NotesService(AsyncMock(), sub)
+
+    await service.unlike_note(238483442)
+
+    sub.delete.assert_awaited_once_with(
+        "comment/238483442/reaction",
+        json={"publication_id": None, "reaction": "❤", "tabId": "for-you"},
+    )

--- a/packages/gateway_notes_mcp/src/gateway_notes_mcp/__init__.py
+++ b/packages/gateway_notes_mcp/src/gateway_notes_mcp/__init__.py
@@ -9,11 +9,27 @@ from gateway_core.capabilities import McpCapability
 if TYPE_CHECKING:
     from fastmcp import FastMCP
 
-_FEATURES = ("mcp:notes:get", "mcp:notes:create", "mcp:notes:delete")
+_FEATURES = (
+    "mcp:notes:get",
+    "mcp:notes:create",
+    "mcp:notes:delete",
+    "mcp:notes:like",
+    "mcp:notes:unlike",
+    "mcp:notes:reply",
+    "mcp:notes:replies:list",
+)
 
 
 def _register(mcp: FastMCP) -> None:
-    from gateway_notes_mcp.tools import create_note, delete_note, get_note
+    from gateway_notes_mcp.tools import (
+        create_note,
+        delete_note,
+        get_note,
+        like_note,
+        list_note_replies,
+        reply_to_note,
+        unlike_note,
+    )
 
     mcp.tool(
         description="Publish a new note to Substack from Markdown content, with an optional link attachment. Requires an explicit base64-encoded Substack credentials token passed via the tool's token argument.",
@@ -54,6 +70,63 @@ def _register(mcp: FastMCP) -> None:
             "substack_endpoint": "GET /reader/comment/{note_id}",
         },
     )(get_note)
+    mcp.tool(
+        description="Add a like to a Substack note by its numeric ID. Requires an explicit base64-encoded Substack credentials token passed via the tool's token argument.",
+        tags={"notes", "write"},
+        annotations=ToolAnnotations(
+            title="Like Note",
+            readOnlyHint=False,
+            destructiveHint=False,
+            idempotentHint=True,
+            openWorldHint=True,
+        ),
+        meta={
+            "category": "notes",
+            "substack_endpoint": "POST /comment/{note_id}/reaction",
+        },
+    )(like_note)
+    mcp.tool(
+        description="Remove a like from a Substack note by its numeric ID. Requires an explicit base64-encoded Substack credentials token passed via the tool's token argument.",
+        tags={"notes", "write"},
+        annotations=ToolAnnotations(
+            title="Unlike Note",
+            readOnlyHint=False,
+            destructiveHint=False,
+            idempotentHint=True,
+            openWorldHint=True,
+        ),
+        meta={
+            "category": "notes",
+            "substack_endpoint": "DELETE /comment/{note_id}/reaction",
+        },
+    )(unlike_note)
+    mcp.tool(
+        description="Reply to a Substack note or to any comment within its thread, from Markdown content. Requires an explicit base64-encoded Substack credentials token passed via the tool's token argument.",
+        tags={"notes", "write"},
+        annotations=ToolAnnotations(
+            title="Reply To Note",
+            readOnlyHint=False,
+            destructiveHint=False,
+            idempotentHint=False,
+            openWorldHint=True,
+        ),
+        meta={"category": "notes", "substack_endpoint": "POST /comment/feed/"},
+    )(reply_to_note)
+    mcp.tool(
+        description="List the direct replies to a Substack note by its numeric ID. Requires an explicit base64-encoded Substack credentials token passed via the tool's token argument.",
+        tags={"notes", "read"},
+        annotations=ToolAnnotations(
+            title="List Note Replies",
+            readOnlyHint=True,
+            destructiveHint=False,
+            idempotentHint=True,
+            openWorldHint=True,
+        ),
+        meta={
+            "category": "notes",
+            "substack_endpoint": "GET /reader/comment/{note_id}/replies",
+        },
+    )(list_note_replies)
 
 
 def capability() -> McpCapability:

--- a/packages/gateway_notes_mcp/src/gateway_notes_mcp/tools.py
+++ b/packages/gateway_notes_mcp/src/gateway_notes_mcp/tools.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 from typing import Any
 
 from gateway_mcp_common.clients import _authenticated_clients
-from gateway_notes.schemas import CreateNoteResponse, NoteResponse
+from gateway_notes.schemas import (
+    CreateNoteResponse,
+    NoteRepliesResponse,
+    NoteReplyCreatedResponse,
+    NoteResponse,
+)
 from gateway_notes.service import NotesService
 
 
@@ -25,3 +30,27 @@ async def delete_note(note_id: int, token: str) -> str:
     async with _authenticated_clients(token) as (pub, sub):
         await NotesService(pub, sub).delete_note(note_id)
     return f"Note {note_id} deleted successfully."
+
+
+async def like_note(note_id: int, token: str) -> str:
+    async with _authenticated_clients(token) as (pub, sub):
+        await NotesService(pub, sub).like_note(note_id)
+    return f"Note {note_id} liked successfully."
+
+
+async def unlike_note(note_id: int, token: str) -> str:
+    async with _authenticated_clients(token) as (pub, sub):
+        await NotesService(pub, sub).unlike_note(note_id)
+    return f"Note {note_id} unliked successfully."
+
+
+async def reply_to_note(note_id: int, body: str, token: str) -> dict[str, Any]:
+    async with _authenticated_clients(token) as (pub, sub):
+        created = await NotesService(pub, sub).reply_to_note(note_id, body)
+    return NoteReplyCreatedResponse.from_substack(created).model_dump(exclude_none=True)
+
+
+async def list_note_replies(note_id: int, token: str) -> dict[str, Any]:
+    async with _authenticated_clients(token) as (pub, sub):
+        replies = await NotesService(pub, sub).list_note_replies(note_id)
+    return NoteRepliesResponse.from_substack(replies).model_dump(exclude_none=True)

--- a/packages/gateway_notes_rest/src/gateway_notes_rest/__init__.py
+++ b/packages/gateway_notes_rest/src/gateway_notes_rest/__init__.py
@@ -6,6 +6,10 @@ _FEATURES = (
     "api:notes:get",
     "api:notes:create",
     "api:notes:delete",
+    "api:notes:like",
+    "api:notes:unlike",
+    "api:notes:reply",
+    "api:notes:replies:list",
 )
 
 

--- a/packages/gateway_notes_rest/src/gateway_notes_rest/router.py
+++ b/packages/gateway_notes_rest/src/gateway_notes_rest/router.py
@@ -3,12 +3,24 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Path
+from pydantic import BaseModel, Field
 
-from gateway_notes.schemas import CreateNoteRequest, CreateNoteResponse, NoteResponse
+from gateway_notes.schemas import (
+    CreateNoteRequest,
+    CreateNoteResponse,
+    NoteRepliesResponse,
+    NoteReplyCreatedResponse,
+    NoteResponse,
+)
 from gateway_notes.service import NotesService
 from gateway_notes_rest.deps import get_notes_service
+from gateway_rest_common.deps import get_credentials
 
 router = APIRouter(tags=["notes"])
+
+
+class NoteReplyRequest(BaseModel):
+    body: str = Field(min_length=1)
 
 
 @router.get(
@@ -45,3 +57,61 @@ async def create_note(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     return CreateNoteResponse.from_substack(note)
+
+
+@router.put(
+    "/notes/{note_id}/like",
+    status_code=204,
+    dependencies=[Depends(get_credentials)],
+)
+async def like_note(
+    note_id: Annotated[int, Path(gt=0)],
+    service: Annotated[NotesService, Depends(get_notes_service)],
+) -> None:
+    """Add a like to a Substack note."""
+    await service.like_note(note_id)
+
+
+@router.delete(
+    "/notes/{note_id}/like",
+    status_code=204,
+    dependencies=[Depends(get_credentials)],
+)
+async def unlike_note(
+    note_id: Annotated[int, Path(gt=0)],
+    service: Annotated[NotesService, Depends(get_notes_service)],
+) -> None:
+    """Remove a like from a Substack note."""
+    await service.unlike_note(note_id)
+
+
+@router.post(
+    "/notes/{note_id}/comments",
+    response_model=NoteReplyCreatedResponse,
+    response_model_exclude_none=True,
+    status_code=201,
+    dependencies=[Depends(get_credentials)],
+)
+async def reply_to_note(
+    note_id: Annotated[int, Path(gt=0)],
+    payload: NoteReplyRequest,
+    service: Annotated[NotesService, Depends(get_notes_service)],
+) -> NoteReplyCreatedResponse:
+    """Reply to a note or to any comment in a note thread."""
+    created = await service.reply_to_note(parent_id=note_id, body=payload.body)
+    return NoteReplyCreatedResponse.from_substack(created)
+
+
+@router.get(
+    "/notes/{note_id}/comments",
+    response_model=NoteRepliesResponse,
+    response_model_exclude_none=True,
+    dependencies=[Depends(get_credentials)],
+)
+async def list_note_replies(
+    note_id: Annotated[int, Path(gt=0)],
+    service: Annotated[NotesService, Depends(get_notes_service)],
+) -> NoteRepliesResponse:
+    """List direct replies to a note (or any node in its thread)."""
+    replies = await service.list_note_replies(note_id)
+    return NoteRepliesResponse.from_substack(replies)

--- a/packages/gateway_oss/features/api/note_engagement.feature
+++ b/packages/gateway_oss/features/api/note_engagement.feature
@@ -1,0 +1,52 @@
+Feature: Note engagement endpoints
+  As an API consumer
+  I want to like, unlike, and reply to Substack notes via the gateway
+  So that I can manage note engagement programmatically
+
+  Scenario: Successfully like a note
+    Given a valid gateway token "test-token" and publication URL "https://example.substack.com"
+    And the Substack like-note endpoint returns status 200 for note 234058408
+    When I send PUT /api/v1/notes/234058408/like
+    Then the response status code is 204
+
+  Scenario: Like note Substack API error returns 502
+    Given a valid gateway token "test-token" and publication URL "https://example.substack.com"
+    And the Substack like-note endpoint returns status 503 for note 234058408
+    When I send PUT /api/v1/notes/234058408/like
+    Then the response status code is 502
+
+  Scenario: Like note authentication failure returns 401
+    Given a valid gateway token "test-token" and publication URL "https://example.substack.com"
+    And the Substack like-note endpoint returns status 401 for note 234058408
+    When I send PUT /api/v1/notes/234058408/like
+    Then the response status code is 401
+
+  Scenario: Missing x-gateway-token header returns 422 on like
+    When I send PUT /api/v1/notes/234058408/like
+    Then the response status code is 422
+
+  Scenario: Successfully unlike a note
+    Given a valid gateway token "test-token" and publication URL "https://example.substack.com"
+    And the Substack unlike-note endpoint returns status 204 for note 238483442
+    When I send DELETE /api/v1/notes/238483442/like
+    Then the response status code is 204
+
+  Scenario: Unlike note authentication failure returns 401
+    Given a valid gateway token "test-token" and publication URL "https://example.substack.com"
+    And the Substack unlike-note endpoint returns status 401 for note 238483442
+    When I send DELETE /api/v1/notes/238483442/like
+    Then the response status code is 401
+
+  Scenario: Successfully reply to a note
+    Given a valid gateway token "test-token" and publication URL "https://example.substack.com"
+    And the Substack note-reply endpoint returns id 555
+    When I send POST /api/v1/notes/234058408/comments with JSON body {"body": "nice"}
+    Then the response status code is 201
+    And the response field "id" is 555
+
+  Scenario: List replies to a note
+    Given a valid gateway token "test-token" and publication URL "https://example.substack.com"
+    And the Substack note-replies endpoint returns two replies for note 234058408
+    When I send GET /api/v1/notes/234058408/comments
+    Then the response status code is 200
+    And the response list "items" has 2 items

--- a/packages/gateway_oss/features/api/root.feature
+++ b/packages/gateway_oss/features/api/root.feature
@@ -13,3 +13,7 @@ Feature: Root endpoint
     And the "gateway-oss" module features contain "api:profiles:posts:list"
     And the "gateway-oss" module features contain "mcp:notes:create"
     And the "gateway-oss" module features contain "mcp:posts:get"
+    And the "gateway-oss" module features contain "api:notes:like"
+    And the "gateway-oss" module features contain "api:notes:reply"
+    And the "gateway-oss" module features contain "mcp:notes:like"
+    And the "gateway-oss" module features contain "mcp:notes:replies:list"

--- a/packages/gateway_oss/features/mcp/note_engagement.feature
+++ b/packages/gateway_oss/features/mcp/note_engagement.feature
@@ -1,0 +1,28 @@
+Feature: MCP note engagement tools
+  As an AI assistant
+  I want to like, unlike, and reply to Substack notes through MCP
+  So that I can manage note engagement programmatically
+
+  Scenario: like_note returns confirmation message
+    Given a valid MCP token and publication URL "https://example.substack.com"
+    And the Substack like-note endpoint returns status 200 for note 234058408
+    When I call the MCP tool like_note with note_id 234058408
+    Then the MCP result is "Note 234058408 liked successfully."
+
+  Scenario: unlike_note returns confirmation message
+    Given a valid MCP token and publication URL "https://example.substack.com"
+    And the Substack unlike-note endpoint returns status 204 for note 238483442
+    When I call the MCP tool unlike_note with note_id 238483442
+    Then the MCP result is "Note 238483442 unliked successfully."
+
+  Scenario: reply_to_note returns the created reply id
+    Given a valid MCP token and publication URL "https://example.substack.com"
+    And the Substack note-reply endpoint returns id 555
+    When I call the MCP tool reply_to_note with note_id 234058408 and body "nice"
+    Then the MCP result field "id" is "555"
+
+  Scenario: list_note_replies returns the replies
+    Given a valid MCP token and publication URL "https://example.substack.com"
+    And the Substack note-replies endpoint returns two replies for note 234058408
+    When I call the MCP tool list_note_replies with note_id 234058408
+    Then the MCP result list "items" has 2 items

--- a/packages/gateway_oss/features/steps/common.py
+++ b/packages/gateway_oss/features/steps/common.py
@@ -118,6 +118,12 @@ def step_field_string(context, field, value):
     )
 
 
+@then('the response field "{field}" is {value:d}')
+def step_response_field_equals_int(context, field, value):
+    body = context.response.json()
+    assert body.get(field) == value, f"{field}={body.get(field)!r} != {value}"
+
+
 @then('the response field "{field}" is not null')
 def step_field_not_null(context, field):
     body = context.response.json()

--- a/packages/gateway_oss/features/steps/mcp_tools.py
+++ b/packages/gateway_oss/features/steps/mcp_tools.py
@@ -15,7 +15,15 @@ from behave import given, then, when
 from gateway_comments_mcp.tools import get_post_comments
 from gateway_following_mcp.tools import get_my_following
 from gateway_me_mcp.tools import get_me, get_my_notes, get_my_posts
-from gateway_notes_mcp.tools import create_note, delete_note, get_note
+from gateway_notes_mcp.tools import (
+    create_note,
+    delete_note,
+    get_note,
+    like_note,
+    list_note_replies,
+    reply_to_note,
+    unlike_note,
+)
 from gateway_posts_mcp.tools import get_post
 from gateway_profiles_mcp.tools import get_profile, get_profile_notes, get_profile_posts
 
@@ -72,6 +80,26 @@ def step_call_create_note(context, content):
 @when("I call the MCP tool delete_note with note_id {note_id:d}")
 def step_call_delete_note(context, note_id):
     _call(context, delete_note(note_id=note_id, token=context.mcp_token))
+
+
+@when("I call the MCP tool like_note with note_id {note_id:d}")
+def step_call_like_note(context, note_id):
+    _call(context, like_note(note_id=note_id, token=context.mcp_token))
+
+
+@when("I call the MCP tool unlike_note with note_id {note_id:d}")
+def step_call_unlike_note(context, note_id):
+    _call(context, unlike_note(note_id=note_id, token=context.mcp_token))
+
+
+@when('I call the MCP tool reply_to_note with note_id {note_id:d} and body "{body}"')
+def step_call_reply_to_note(context, note_id, body):
+    _call(context, reply_to_note(note_id=note_id, body=body, token=context.mcp_token))
+
+
+@when("I call the MCP tool list_note_replies with note_id {note_id:d}")
+def step_call_list_note_replies(context, note_id):
+    _call(context, list_note_replies(note_id=note_id, token=context.mcp_token))
 
 
 # ------------------------------------------------------------------
@@ -146,7 +174,7 @@ def step_mcp_field_not_null(context, field):
 def step_mcp_field_string(context, field, value):
     assert context.mcp_error is None, f"MCP tool raised: {context.mcp_error}"
     actual = context.mcp_result[field]
-    assert actual == value, f'Expected "{field}" to be "{value}", got "{actual}"'
+    assert str(actual) == value, f'Expected "{field}" to be "{value}", got "{actual}"'
 
 
 @then('the MCP result is "{value}"')

--- a/packages/gateway_oss/features/steps/note_engagement.py
+++ b/packages/gateway_oss/features/steps/note_engagement.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import httpx
+from behave import given, when
+from common import SUBSTACK_BASE
+
+
+def _reaction_url(note_id: int) -> str:
+    return f"{SUBSTACK_BASE}/api/v1/comment/{note_id}/reaction"
+
+
+def _reply_feed_url() -> str:
+    return f"{SUBSTACK_BASE}/api/v1/comment/feed/"
+
+
+def _replies_url(note_id: int) -> str:
+    return f"{SUBSTACK_BASE}/api/v1/reader/comment/{note_id}/replies"
+
+
+@given("the Substack like-note endpoint returns status {status:d} for note {note_id:d}")
+def step_like_note_status(context, status, note_id):
+    context.respx_mock.post(_reaction_url(note_id)).mock(
+        return_value=httpx.Response(status)
+    )
+
+
+@given(
+    "the Substack unlike-note endpoint returns status {status:d} for note {note_id:d}"
+)
+def step_unlike_note_status(context, status, note_id):
+    context.respx_mock.delete(_reaction_url(note_id)).mock(
+        return_value=httpx.Response(status)
+    )
+
+
+@given("the Substack note-reply endpoint returns id {reply_id:d}")
+def step_note_reply_returns_id(context, reply_id):
+    context.respx_mock.post(_reply_feed_url()).mock(
+        return_value=httpx.Response(
+            200, json={"id": reply_id, "date": "2026-08-04", "status": "published"}
+        )
+    )
+
+
+@given("the Substack note-replies endpoint returns two replies for note {note_id:d}")
+def step_note_replies_returns_two(context, note_id):
+    context.respx_mock.get(_replies_url(note_id)).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "commentBranches": [
+                    {"comment": {"id": 1, "body": "first"}},
+                    {"comment": {"id": 2, "body": "second"}},
+                ]
+            },
+        )
+    )
+
+
+@when("I send PUT {path}")
+def step_send_put_no_body(context, path):
+    context.response = context.client.put(path, headers=context.headers)


### PR DESCRIPTION
## Summary

Adds note engagement to the notes fleet across the service, REST, and MCP surfaces:

- **like / unlike** a note
- **reply** to a note (or any comment in its thread)
- **list replies** to a note

## Changes

- `gateway_core`: rich comment models (`SubstackPostComment`, `SubstackCommentBranch`, `SubstackCommentBranchesResponse`).
- `gateway_notes`: four `NotesService` methods (`like_note`, `unlike_note`, `reply_to_note`, `list_note_replies`) plus `NoteReplyCreatedResponse` / `NoteReplyItem` / `NoteRepliesResponse` schemas, with unit tests.
- `gateway_notes_rest`: `PUT/DELETE /notes/{id}/like`, `POST/GET /notes/{id}/comments`, and the matching `api:notes:*` capability features.
- `gateway_notes_mcp`: `like_note`, `unlike_note`, `reply_to_note`, `list_note_replies` tools plus `mcp:notes:*` capability features.

The new `api:notes:*` and `mcp:notes:*` capabilities surface on the `gateway-oss` module at `/`.

## Validation

`ruff check`, `ruff format --check`, `ty check`, `uv build --all-packages`, `pytest` (52 passed), and the full behave suite (19 features / 126 scenarios / 544 steps) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)