### PR TITLE
test: cover the post comment lifecycle end-to-end

### DIFF
--- a/packages/gateway_oss/e2e/comments.feature
+++ b/packages/gateway_oss/e2e/comments.feature
@@ -1,0 +1,39 @@
+Feature: Post comment endpoints
+
+  Scenario: Lifecycle — create, reply, list, react, delete
+    Given valid credentials
+    And a test post ID
+    # 1) create a top-level comment under the post
+    When I create a post comment with body "e2e top-level — safe to delete"
+    Then the response status is 201
+    And the response has field "id"
+    Given the created post comment ID is saved as the top
+    # 2) reply to it
+    When I reply to the top post comment with body "e2e reply — safe to delete"
+    Then the response status is 201
+    And the response has field "id"
+    Given the created post comment ID is saved as the reply
+    # 3) list replies of the top — must contain our reply
+    When I list replies of the top post comment
+    Then the response status is 200
+    And the response field "items" is a list
+    And the items contain the reply post comment
+    # 4) fetch the top comment
+    When I fetch the top post comment
+    Then the response status is 200
+    And the response has field "id"
+    # 5) react and un-react
+    When I like the top post comment
+    Then the response status is 204
+    When I unlike the top post comment
+    Then the response status is 204
+    # 6) cleanup — delete reply, then top
+    When I delete the reply post comment
+    Then the response status is 204
+    When I delete the top post comment
+    Then the response status is 204
+
+  Scenario: Reply to a non-existent comment returns 404
+    Given valid credentials
+    When I reply to post comment "1" with body "should fail"
+    Then the response status is 404

--- a/packages/gateway_oss/e2e/steps/common.py
+++ b/packages/gateway_oss/e2e/steps/common.py
@@ -127,6 +127,102 @@ def step_get_post_comments(context):
     )
 
 
+# --- Post comment lifecycle -------------------------------------------------
+
+
+@when('I create a post comment with body "{body}"')
+def step_create_post_comment(context, body):
+    context.response = context.client.post(
+        f"/api/v1/posts/{context.post_id}/comments",
+        json={"body": body},
+        headers=context.headers,
+    )
+
+
+@given("the created post comment ID is saved as the top")
+def step_save_top_post_comment(context):
+    context.top_post_comment_id = str(context.response.json()["id"])
+
+
+@given("the created post comment ID is saved as the reply")
+def step_save_reply_post_comment(context):
+    context.reply_post_comment_id = str(context.response.json()["id"])
+
+
+@when('I reply to the top post comment with body "{body}"')
+def step_reply_to_top(context, body):
+    context.response = context.client.post(
+        f"/api/v1/comments/{context.top_post_comment_id}/comments",
+        json={"body": body},
+        headers=context.headers,
+    )
+
+
+@when('I reply to post comment "{comment_id}" with body "{body}"')
+def step_reply_to_explicit(context, comment_id, body):
+    context.response = context.client.post(
+        f"/api/v1/comments/{comment_id}/comments",
+        json={"body": body},
+        headers=context.headers,
+    )
+
+
+@when("I list replies of the top post comment")
+def step_list_replies_of_top(context):
+    context.response = context.client.get(
+        f"/api/v1/comments/{context.top_post_comment_id}/comments",
+        headers=context.headers,
+    )
+
+
+@then("the items contain the reply post comment")
+def step_items_contain_reply(context):
+    items = context.response.json()["items"]
+    target = int(context.reply_post_comment_id)
+    assert any(it["id"] == target for it in items), (
+        f"reply id={target} not in listing: {[it['id'] for it in items]}"
+    )
+
+
+@when("I fetch the top post comment")
+def step_fetch_top(context):
+    context.response = context.client.get(
+        f"/api/v1/comments/{context.top_post_comment_id}", headers=context.headers
+    )
+
+
+@when("I like the top post comment")
+def step_like_top(context):
+    context.response = context.client.post(
+        f"/api/v1/comments/{context.top_post_comment_id}/reaction",
+        headers=context.headers,
+    )
+
+
+@when("I unlike the top post comment")
+def step_unlike_top(context):
+    context.response = context.client.delete(
+        f"/api/v1/comments/{context.top_post_comment_id}/reaction",
+        headers=context.headers,
+    )
+
+
+@when("I delete the reply post comment")
+def step_delete_reply_post_comment(context):
+    context.response = context.client.delete(
+        f"/api/v1/comments/{context.reply_post_comment_id}",
+        headers=context.headers,
+    )
+
+
+@when("I delete the top post comment")
+def step_delete_top_post_comment(context):
+    context.response = context.client.delete(
+        f"/api/v1/comments/{context.top_post_comment_id}",
+        headers=context.headers,
+    )
+
+
 @then("the response status is {status:d}")
 def step_status(context, status):
     assert context.response.status_code == status, (


### PR DESCRIPTION
## What

Add a live end-to-end suite for the post comment write surface to the OSS `e2e/` runner, alongside the existing `notes.feature`.

- `e2e/comments.feature` — two scenarios:
  - **Lifecycle**: create top-level comment → reply → list replies (asserts the reply is present) → fetch → like → unlike → delete reply → delete top.
  - **404 path**: reply to a non-existent comment returns 404.
- `e2e/steps/common.py` — the 12 lifecycle step definitions. The base steps (`valid credentials`, `a test post ID`, status/field/list assertions) already existed.

## Why

The comment create/reply/delete/like/unlike/reply-listing surface shipped in 3.6.0 with behave+respx integration coverage, but that layer only exercises wiring against a mocked Substack. The live end-to-end lifecycle — the only test that drives the full round-trip against a running gateway and real Substack — was not carried over into the OSS e2e runner. This restores it.

## Validation

- Routes match the assertions 1:1 (201 / 204 / `id` / `items` / 404).
- `ruff check` and `ruff format --check` clean.
- `behave --dry-run` resolves every step — no undefined or ambiguous steps.
- The suite skips gracefully when `SUBSTACK_GATEWAY_TOKEN` / `E2E_POST_ID` are not configured (same pattern as the other e2e features).

🤖 Generated with [Claude Code](https://claude.com/claude-code)