### PR TITLE
fix: tornar connect_sid opcional na autenticação

### DIFF
--- a/packages/gateway_core/src/gateway_core/auth.py
+++ b/packages/gateway_core/src/gateway_core/auth.py
@@ -39,8 +39,8 @@ def decode_bearer_credentials(raw: str) -> BearerCredentials:
     parsed = urlparse(credentials.publication_url)
     if parsed.scheme not in ("http", "https") or not parsed.netloc:
         raise ValueError("Token must contain a valid HTTP or HTTPS publication_url")
-    if not credentials.substack_sid or not credentials.connect_sid:
-        raise ValueError("Token must contain substack_sid and connect_sid")
+    if not credentials.substack_sid:
+        raise ValueError("Token must contain substack_sid")
     return credentials
 
 
@@ -52,7 +52,6 @@ async def make_publication_client(
 ) -> AsyncIterator[PublicationClient]:
     """Yield an authenticated PublicationClient from already-decoded credentials."""
     assert credentials.substack_sid is not None
-    assert credentials.connect_sid is not None
     async with PublicationClient(
         substack_sid=credentials.substack_sid,
         connect_sid=credentials.connect_sid,
@@ -69,7 +68,6 @@ async def make_substack_client(
 ) -> AsyncIterator[SubstackClient]:
     """Yield an authenticated SubstackClient from already-decoded credentials."""
     assert credentials.substack_sid is not None
-    assert credentials.connect_sid is not None
     async with SubstackClient(
         substack_sid=credentials.substack_sid,
         connect_sid=credentials.connect_sid,

--- a/packages/gateway_core/src/gateway_core/client/base.py
+++ b/packages/gateway_core/src/gateway_core/client/base.py
@@ -199,10 +199,12 @@ class SubstackHTTPBase:
     def __init__(
         self,
         substack_sid: str,
-        connect_sid: str,
+        connect_sid: str | None,
         request_id: str | None = None,
     ) -> None:
-        self._cookies = {"substack.sid": substack_sid, "connect.sid": connect_sid}
+        self._cookies = {"substack.sid": substack_sid}
+        if connect_sid:
+            self._cookies["connect.sid"] = connect_sid
         self._http: httpx.AsyncClient | None = None
         self._rid = f"[{request_id}] " if request_id else ""
 

--- a/packages/gateway_core/src/gateway_core/client/publication.py
+++ b/packages/gateway_core/src/gateway_core/client/publication.py
@@ -15,7 +15,7 @@ class PublicationClient(SubstackHTTPBase):
     def __init__(
         self,
         substack_sid: str,
-        connect_sid: str,
+        connect_sid: str | None,
         publication_url: str,
         request_id: str | None = None,
     ) -> None:

--- a/packages/gateway_core/src/gateway_core/client/substack.py
+++ b/packages/gateway_core/src/gateway_core/client/substack.py
@@ -26,7 +26,7 @@ class SubstackClient(SubstackHTTPBase):
     def __init__(
         self,
         substack_sid: str,
-        connect_sid: str,
+        connect_sid: str | None,
         request_id: str | None = None,
     ) -> None:
         super().__init__(substack_sid, connect_sid, request_id)

--- a/packages/gateway_core/tests/test_auth.py
+++ b/packages/gateway_core/tests/test_auth.py
@@ -35,6 +35,31 @@ def test_decode_bearer_credentials_requires_publication_url() -> None:
         )
 
 
+def test_decode_bearer_credentials_allows_missing_connect_sid() -> None:
+    credentials = decode_bearer_credentials(
+        _encode(
+            {
+                "publication_url": "https://example.substack.com",
+                "substack_sid": "sid",
+            }
+        )
+    )
+
+    assert credentials.connect_sid is None
+
+
+def test_decode_bearer_credentials_requires_substack_sid() -> None:
+    with pytest.raises(ValueError, match="substack_sid"):
+        decode_bearer_credentials(
+            _encode(
+                {
+                    "publication_url": "https://example.substack.com",
+                    "connect_sid": "csid",
+                }
+            )
+        )
+
+
 def test_decode_bearer_credentials_rejects_invalid_publication_url() -> None:
     with pytest.raises(ValueError, match="valid HTTP or HTTPS publication_url"):
         decode_bearer_credentials(


### PR DESCRIPTION
Remove a obrigatoriedade do connect_sid pois o Substack 
já não utiliza este cookie em algumas contas.