### PR TITLE
feat: make the MCP token argument optional

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,7 @@ Client request
 
 Gateway authentication and Substack authentication are separate concerns. REST requests carry an `x-gateway-token` header whose value is a **base64-encoded JSON token** containing `publication_url`, `substack_sid`, and `connect_sid` (Substack session cookies plus the target publication URL). `gateway_core.auth` decodes this token; each domain's `_rest` package's `deps.py` uses it to construct per-request HTTP clients.
 
-The MCP layer does not resolve Substack credentials through OAuth. Authenticated MCP tools take an explicit `token` argument carrying the same base64-encoded Substack credentials object. An extension's OAuth provider may still authorize access to the gateway itself, but it does not store or inject Substack credentials.
+The MCP layer does not resolve Substack credentials through OAuth. Authenticated MCP tools take an optional `token` argument carrying the same base64-encoded Substack credentials object; when it is supplied it is always used. When it is omitted, the gateway asks the installed credential resolver (`gateway_core.credentials`) to map the authenticated caller to Substack credentials. This repository installs no resolver, so a call without a token raises `MissingCredentialsError`, whose message tells the caller to pass `token`. An extension may separately register its own resolver via `GatewayExtension.get_credential_resolver`, and may authorize access to the gateway itself through an MCP auth provider, but neither the gateway nor its own auth provider stores or injects Substack credentials.
 
 ### HTTP clients
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -26,7 +26,7 @@ The codebase also defines authenticated MCP operations for:
 - `get_my_posts`
 - `get_my_following`
 
-Those tools require an explicit `token` argument carrying the base64-encoded Substack credential JSON.
+The `token` argument on those tools is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.
 
 Whether authenticated tools are exposed depends on the active runtime and extension setup.
 

--- a/packages/gateway_comments_mcp/src/gateway_comments_mcp/__init__.py
+++ b/packages/gateway_comments_mcp/src/gateway_comments_mcp/__init__.py
@@ -34,7 +34,7 @@ def _register(mcp: FastMCP) -> None:
     )
 
     mcp.tool(
-        description="Retrieve all comments for a Substack post by its numeric ID. Requires an explicit base64-encoded Substack credentials token passed via the tool's token argument.",
+        description="Retrieve all comments for a Substack post by its numeric ID. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"posts", "comments", "read"},
         annotations=ToolAnnotations(
             title="Get Post Comments",
@@ -50,7 +50,7 @@ def _register(mcp: FastMCP) -> None:
     )(get_post_comments)
 
     mcp.tool(
-        description="Create a top-level comment on a Substack post. Requires an explicit base64-encoded Substack credentials token via the token argument.",
+        description="Create a top-level comment on a Substack post. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"comments", "write"},
         annotations=ToolAnnotations(
             title="Create Post Comment",
@@ -66,7 +66,7 @@ def _register(mcp: FastMCP) -> None:
     )(create_post_comment)
 
     mcp.tool(
-        description="Reply to an existing Substack post comment. Requires an explicit base64-encoded Substack credentials token via the token argument.",
+        description="Reply to an existing Substack post comment. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"comments", "write"},
         annotations=ToolAnnotations(
             title="Reply To Post Comment",
@@ -82,7 +82,7 @@ def _register(mcp: FastMCP) -> None:
     )(reply_to_post_comment)
 
     mcp.tool(
-        description="Fetch a single Substack post comment by its numeric ID. Requires an explicit base64-encoded Substack credentials token via the token argument.",
+        description="Fetch a single Substack post comment by its numeric ID. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"comments", "read"},
         annotations=ToolAnnotations(
             title="Get Post Comment",
@@ -95,7 +95,7 @@ def _register(mcp: FastMCP) -> None:
     )(get_post_comment)
 
     mcp.tool(
-        description="Delete a Substack post comment by its numeric ID. Requires an explicit base64-encoded Substack credentials token via the token argument.",
+        description="Delete a Substack post comment by its numeric ID. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"comments", "write", "delete"},
         annotations=ToolAnnotations(
             title="Delete Post Comment",
@@ -108,7 +108,7 @@ def _register(mcp: FastMCP) -> None:
     )(delete_post_comment)
 
     mcp.tool(
-        description="List the direct replies to a Substack post comment. Requires an explicit base64-encoded Substack credentials token via the token argument.",
+        description="List the direct replies to a Substack post comment. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"comments", "read"},
         annotations=ToolAnnotations(
             title="List Post Comment Replies",
@@ -124,7 +124,7 @@ def _register(mcp: FastMCP) -> None:
     )(list_post_comment_replies)
 
     mcp.tool(
-        description="Add a like reaction to a Substack post comment. Requires an explicit base64-encoded Substack credentials token via the token argument.",
+        description="Add a like reaction to a Substack post comment. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"comments", "write"},
         annotations=ToolAnnotations(
             title="Like Post Comment",
@@ -140,7 +140,7 @@ def _register(mcp: FastMCP) -> None:
     )(like_post_comment)
 
     mcp.tool(
-        description="Remove your like reaction from a Substack post comment. Requires an explicit base64-encoded Substack credentials token via the token argument.",
+        description="Remove your like reaction from a Substack post comment. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"comments", "write"},
         annotations=ToolAnnotations(
             title="Unlike Post Comment",

--- a/packages/gateway_comments_mcp/src/gateway_comments_mcp/tools.py
+++ b/packages/gateway_comments_mcp/src/gateway_comments_mcp/tools.py
@@ -11,13 +11,15 @@ from gateway_comments.service import CommentNotFoundError, CommentsService
 from gateway_mcp_common.clients import _authenticated_clients
 
 
-async def get_post_comments(post_id: int, token: str) -> dict[str, Any]:
+async def get_post_comments(post_id: int, token: str | None = None) -> dict[str, Any]:
     async with _authenticated_clients(token) as (pub, sub):
         comments = await CommentsService(pub, sub).get_comments_for_post(post_id)
     return CommentsResponse.from_substack(comments).model_dump()
 
 
-async def create_post_comment(post_id: int, body: str, token: str) -> dict[str, Any]:
+async def create_post_comment(
+    post_id: int, body: str, token: str | None = None
+) -> dict[str, Any]:
     async with _authenticated_clients(token) as (pub, sub):
         comment = await CommentsService(pub, sub).create_top_level_comment(
             post_id, body
@@ -26,7 +28,7 @@ async def create_post_comment(post_id: int, body: str, token: str) -> dict[str, 
 
 
 async def reply_to_post_comment(
-    comment_id: int, body: str, token: str
+    comment_id: int, body: str, token: str | None = None
 ) -> dict[str, Any]:
     async with _authenticated_clients(token) as (pub, sub):
         try:
@@ -36,19 +38,21 @@ async def reply_to_post_comment(
     return PostCommentResponse.from_substack(comment).model_dump(exclude_none=True)
 
 
-async def get_post_comment(comment_id: int, token: str) -> dict[str, Any]:
+async def get_post_comment(comment_id: int, token: str | None = None) -> dict[str, Any]:
     async with _authenticated_clients(token) as (pub, sub):
         comment = await CommentsService(pub, sub).get_post_comment(comment_id)
     return PostCommentResponse.from_substack(comment).model_dump(exclude_none=True)
 
 
-async def delete_post_comment(comment_id: int, token: str) -> str:
+async def delete_post_comment(comment_id: int, token: str | None = None) -> str:
     async with _authenticated_clients(token) as (pub, sub):
         await CommentsService(pub, sub).delete_comment(comment_id)
     return f"Comment {comment_id} deleted successfully."
 
 
-async def list_post_comment_replies(comment_id: int, token: str) -> dict[str, Any]:
+async def list_post_comment_replies(
+    comment_id: int, token: str | None = None
+) -> dict[str, Any]:
     async with _authenticated_clients(token) as (pub, sub):
         replies = await CommentsService(pub, sub).list_comment_replies(comment_id)
     return PostCommentRepliesResponse.from_substack(replies).model_dump(
@@ -56,13 +60,13 @@ async def list_post_comment_replies(comment_id: int, token: str) -> dict[str, An
     )
 
 
-async def like_post_comment(comment_id: int, token: str) -> str:
+async def like_post_comment(comment_id: int, token: str | None = None) -> str:
     async with _authenticated_clients(token) as (pub, sub):
         await CommentsService(pub, sub).like_comment(comment_id)
     return f"Comment {comment_id} liked successfully."
 
 
-async def unlike_post_comment(comment_id: int, token: str) -> str:
+async def unlike_post_comment(comment_id: int, token: str | None = None) -> str:
     async with _authenticated_clients(token) as (pub, sub):
         await CommentsService(pub, sub).unlike_comment(comment_id)
     return f"Comment {comment_id} unliked successfully."

--- a/packages/gateway_core/src/gateway_core/auth.py
+++ b/packages/gateway_core/src/gateway_core/auth.py
@@ -17,6 +17,28 @@ class BearerCredentials(BaseModel):
     connect_sid: str | None = None
 
 
+def validate_bearer_credentials(
+    credentials: BearerCredentials, *, source: str = "Token"
+) -> None:
+    """Validate that credentials carry a usable publication URL and session cookies.
+
+    Applies the same three checks regardless of where the credentials came
+    from: a decoded ``token`` argument, or a value returned by an installed
+    :class:`~gateway_core.credentials.CredentialResolver`. ``source`` names the
+    origin in the raised message (e.g. ``"Token"`` or ``"Resolved credentials"``).
+
+    Raises:
+        ValueError: If required fields are absent or malformed.
+    """
+    if not credentials.publication_url:
+        raise ValueError(f"{source} must contain publication_url")
+    parsed = urlparse(credentials.publication_url)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        raise ValueError(f"{source} must contain a valid HTTP or HTTPS publication_url")
+    if not credentials.substack_sid or not credentials.connect_sid:
+        raise ValueError(f"{source} must contain substack_sid and connect_sid")
+
+
 def decode_bearer_credentials(raw: str) -> BearerCredentials:
     """Decode a base64-encoded JSON gateway token into BearerCredentials.
 
@@ -34,13 +56,7 @@ def decode_bearer_credentials(raw: str) -> BearerCredentials:
         raise ValueError(
             "Invalid token: expected base64-encoded JSON credentials"
         ) from exc
-    if not credentials.publication_url:
-        raise ValueError("Token must contain publication_url")
-    parsed = urlparse(credentials.publication_url)
-    if parsed.scheme not in ("http", "https") or not parsed.netloc:
-        raise ValueError("Token must contain a valid HTTP or HTTPS publication_url")
-    if not credentials.substack_sid or not credentials.connect_sid:
-        raise ValueError("Token must contain substack_sid and connect_sid")
+    validate_bearer_credentials(credentials)
     return credentials
 
 

--- a/packages/gateway_core/src/gateway_core/credentials.py
+++ b/packages/gateway_core/src/gateway_core/credentials.py
@@ -30,9 +30,15 @@ class CredentialResolver(Protocol):
     async def resolve(self, access_token: Any) -> BearerCredentials | None:
         """Return credentials for ``access_token``'s subject, or ``None``.
 
-        ``access_token`` is the transport's authenticated token object, or
+        ``access_token`` is the transport's authenticated token object — in
+        practice, an instance of ``fastmcp.server.auth.AccessToken``, or
         ``None`` when the request carried no authentication. It is typed
-        loosely so this package stays free of transport dependencies.
+        loosely so this package stays free of that dependency.
+
+        Implementations MUST treat ``None`` as unauthenticated and return
+        ``None`` for it rather than serving any stored credential set — a
+        resolver that ignores the distinction would hand one caller's
+        credentials to every anonymous request.
         """
 
 

--- a/packages/gateway_core/src/gateway_core/credentials.py
+++ b/packages/gateway_core/src/gateway_core/credentials.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from gateway_core.auth import BearerCredentials
+
+_MESSAGE = (
+    "No Substack credentials. Pass `token` with base64-encoded credentials, "
+    "or run a deployment that resolves credentials from the authenticated "
+    "session."
+)
+
+
+class MissingCredentialsError(RuntimeError):
+    """Raised when a call carries no usable Substack credentials."""
+
+    def __init__(self, message: str = _MESSAGE) -> None:
+        super().__init__(message)
+
+
+@runtime_checkable
+class CredentialResolver(Protocol):
+    """Resolves the credentials of an already-authenticated caller.
+
+    Implementations map a caller's identity to the Substack credentials stored
+    for them. Returning ``None`` means the caller is not known, which the
+    caller of this protocol reports as :class:`MissingCredentialsError`.
+    """
+
+    async def resolve(self, access_token: Any) -> BearerCredentials | None:
+        """Return credentials for ``access_token``'s subject, or ``None``.
+
+        ``access_token`` is the transport's authenticated token object, or
+        ``None`` when the request carried no authentication. It is typed
+        loosely so this package stays free of transport dependencies.
+        """
+
+
+_resolver: CredentialResolver | None = None
+
+
+def set_credential_resolver(resolver: CredentialResolver | None) -> None:
+    """Install the process-wide resolver. Pass ``None`` to clear it."""
+    global _resolver
+    _resolver = resolver
+
+
+def get_credential_resolver() -> CredentialResolver | None:
+    """Return the installed resolver, or ``None`` when none is installed."""
+    return _resolver

--- a/packages/gateway_core/tests/test_credentials.py
+++ b/packages/gateway_core/tests/test_credentials.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import pytest
+
+from gateway_core.auth import BearerCredentials
+from gateway_core.credentials import (
+    MissingCredentialsError,
+    get_credential_resolver,
+    set_credential_resolver,
+)
+
+
+class _StubResolver:
+    def __init__(self, credentials: BearerCredentials | None) -> None:
+        self._credentials = credentials
+        self.seen: list[object] = []
+
+    async def resolve(self, access_token: object) -> BearerCredentials | None:
+        self.seen.append(access_token)
+        return self._credentials
+
+
+@pytest.fixture(autouse=True)
+def _clear_resolver():
+    set_credential_resolver(None)
+    yield
+    set_credential_resolver(None)
+
+
+def test_registry_starts_empty() -> None:
+    assert get_credential_resolver() is None
+
+
+def test_registry_round_trips() -> None:
+    resolver = _StubResolver(None)
+    set_credential_resolver(resolver)
+    assert get_credential_resolver() is resolver
+
+
+def test_registry_can_be_cleared() -> None:
+    set_credential_resolver(_StubResolver(None))
+    set_credential_resolver(None)
+    assert get_credential_resolver() is None
+
+
+def test_missing_credentials_error_is_actionable() -> None:
+    message = str(MissingCredentialsError())
+    assert "token" in message
+    assert "credentials" in message.lower()
+
+
+def test_missing_credentials_error_is_runtime_error() -> None:
+    assert issubclass(MissingCredentialsError, RuntimeError)

--- a/packages/gateway_drafts_mcp/src/gateway_drafts_mcp/__init__.py
+++ b/packages/gateway_drafts_mcp/src/gateway_drafts_mcp/__init__.py
@@ -38,7 +38,7 @@ def _register(mcp: FastMCP) -> None:
     )
 
     mcp.tool(
-        description="List Substack post drafts for the publication, newest first, in pages of 10 with cursor-based pagination. Pass `next` from a previous response to fetch the following page. Each item contains id, uuid, title, and last-updated timestamp. Requires an explicit base64-encoded Substack credentials token passed via the tool's token argument.",
+        description="List Substack post drafts for the publication, newest first, in pages of 10 with cursor-based pagination. Pass `next` from a previous response to fetch the following page. Each item contains id, uuid, title, and last-updated timestamp. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"drafts", "read"},
         annotations=ToolAnnotations(
             title="List Drafts",
@@ -50,7 +50,7 @@ def _register(mcp: FastMCP) -> None:
         meta={"category": "drafts", "substack_endpoint": "GET /post_management/drafts"},
     )(list_drafts)
     mcp.tool(
-        description="Fetch a Substack post draft by ID. The body is returned as Markdown. Requires an explicit base64-encoded Substack credentials token passed via the tool's token argument.",
+        description="Fetch a Substack post draft by ID. The body is returned as Markdown. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"drafts", "read"},
         annotations=ToolAnnotations(
             title="Get Draft",
@@ -62,7 +62,7 @@ def _register(mcp: FastMCP) -> None:
         meta={"category": "drafts", "substack_endpoint": "GET /drafts/{draft_id}"},
     )(get_draft)
     mcp.tool(
-        description="Create a new Substack post draft with optional title, subtitle, and body. The body accepts Markdown. Requires an explicit base64-encoded Substack credentials token passed via the tool's token argument.",
+        description="Create a new Substack post draft with optional title, subtitle, and body. The body accepts Markdown. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"drafts", "write"},
         annotations=ToolAnnotations(
             title="Create Draft",
@@ -74,7 +74,7 @@ def _register(mcp: FastMCP) -> None:
         meta={"category": "drafts", "substack_endpoint": "POST /drafts"},
     )(create_draft)
     mcp.tool(
-        description="Upload an image to Substack and get back its hosted URL and pixel dimensions. Pass the image as base64 in `image_base64` with its `content_type` (e.g. image/png). Reference the returned URL in a draft body as ![alt](url). Requires an explicit base64-encoded Substack credentials token passed via the tool's token argument.",
+        description="Upload an image to Substack and get back its hosted URL and pixel dimensions. Pass the image as base64 in `image_base64` with its `content_type` (e.g. image/png). Reference the returned URL in a draft body as ![alt](url). The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"drafts", "images", "write"},
         annotations=ToolAnnotations(
             title="Upload Image",
@@ -86,7 +86,7 @@ def _register(mcp: FastMCP) -> None:
         meta={"category": "drafts", "substack_endpoint": "POST /api/v1/image"},
     )(upload_image)
     mcp.tool(
-        description="Update specific fields of a Substack post draft. Only provided fields are changed; omitted fields remain unchanged. Body accepts Markdown. Requires an explicit base64-encoded Substack credentials token passed via the tool's token argument.",
+        description="Update specific fields of a Substack post draft. Only provided fields are changed; omitted fields remain unchanged. Body accepts Markdown. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"drafts", "write"},
         annotations=ToolAnnotations(
             title="Update Draft",
@@ -98,7 +98,7 @@ def _register(mcp: FastMCP) -> None:
         meta={"category": "drafts", "substack_endpoint": "PUT /drafts/{draft_id}"},
     )(update_draft)
     mcp.tool(
-        description="Permanently delete a Substack post draft by its numeric ID. Requires an explicit base64-encoded Substack credentials token passed via the tool's token argument.",
+        description="Permanently delete a Substack post draft by its numeric ID. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"drafts", "write", "delete"},
         annotations=ToolAnnotations(
             title="Delete Draft",
@@ -110,7 +110,7 @@ def _register(mcp: FastMCP) -> None:
         meta={"category": "drafts", "substack_endpoint": "DELETE /drafts/{draft_id}"},
     )(delete_draft)
     mcp.tool(
-        description="Run Substack's Pangram AI-writing detection on a draft. Returns fraction_ai / fraction_ai_assisted / fraction_human plus a human-readable header and details. Requires an explicit base64-encoded Substack credentials token passed via the tool's token argument.",
+        description="Run Substack's Pangram AI-writing detection on a draft. Returns fraction_ai / fraction_ai_assisted / fraction_human plus a human-readable header and details. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"drafts", "read"},
         annotations=ToolAnnotations(
             title="Get AI Detection",
@@ -125,7 +125,7 @@ def _register(mcp: FastMCP) -> None:
         },
     )(get_ai_detection)
     mcp.tool(
-        description="Run Substack's pre-publish validation on a draft, returning any blocking errors and non-blocking suggestions. Call before scheduling. Requires an explicit base64-encoded Substack credentials token passed via the tool's token argument.",
+        description="Run Substack's pre-publish validation on a draft, returning any blocking errors and non-blocking suggestions. Call before scheduling. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"drafts", "read"},
         annotations=ToolAnnotations(
             title="Check Draft",
@@ -140,7 +140,7 @@ def _register(mcp: FastMCP) -> None:
         },
     )(check_draft)
     mcp.tool(
-        description="Schedule a Substack draft for timed release. `scheduled_at` is an ISO-8601 timestamp (UTC recommended, e.g. 2026-09-16T18:24:00Z). `post_audience` and `email_audience` default to only_paid. Requires an explicit base64-encoded Substack credentials token passed via the tool's token argument.",
+        description="Schedule a Substack draft for timed release. `scheduled_at` is an ISO-8601 timestamp (UTC recommended, e.g. 2026-09-16T18:24:00Z). `post_audience` and `email_audience` default to only_paid. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"drafts", "write"},
         annotations=ToolAnnotations(
             title="Schedule Draft",
@@ -155,7 +155,7 @@ def _register(mcp: FastMCP) -> None:
         },
     )(schedule_draft)
     mcp.tool(
-        description="Cancel a Substack draft's scheduled release, returning it to an unscheduled draft. Requires an explicit base64-encoded Substack credentials token passed via the tool's token argument.",
+        description="Cancel a Substack draft's scheduled release, returning it to an unscheduled draft. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"drafts", "write", "delete"},
         annotations=ToolAnnotations(
             title="Unschedule Draft",

--- a/packages/gateway_drafts_mcp/src/gateway_drafts_mcp/tools.py
+++ b/packages/gateway_drafts_mcp/src/gateway_drafts_mcp/tools.py
@@ -17,7 +17,7 @@ from gateway_mcp_common.clients import _authenticated_clients
 
 
 async def list_drafts(
-    token: str,
+    token: str | None = None,
     next: str | None = None,
 ) -> dict[str, Any]:
     async with _authenticated_clients(token) as (publication, substack):
@@ -31,7 +31,7 @@ async def list_drafts(
 
 async def get_draft(
     draft_id: int,
-    token: str,
+    token: str | None = None,
 ) -> dict[str, Any]:
     async with _authenticated_clients(token) as (publication, substack):
         draft = await DraftsService(publication, substack).get_draft(draft_id)
@@ -39,7 +39,7 @@ async def get_draft(
 
 
 async def create_draft(
-    token: str,
+    token: str | None = None,
     title: str | None = None,
     subtitle: str | None = None,
     body: str | None = None,
@@ -55,7 +55,7 @@ async def create_draft(
 
 async def update_draft(
     draft_id: int,
-    token: str,
+    token: str | None = None,
     title: str | None = None,
     subtitle: str | None = None,
     body: str | None = None,
@@ -76,7 +76,7 @@ async def update_draft(
 
 async def delete_draft(
     draft_id: int,
-    token: str,
+    token: str | None = None,
 ) -> str:
     async with _authenticated_clients(token) as (publication, substack):
         await DraftsService(publication, substack).delete_draft(draft_id)
@@ -85,7 +85,7 @@ async def delete_draft(
 
 async def get_ai_detection(
     draft_id: int,
-    token: str,
+    token: str | None = None,
 ) -> dict[str, Any]:
     async with _authenticated_clients(token) as (publication, substack):
         result = await DraftsService(publication, substack).ai_detection(draft_id)
@@ -94,7 +94,7 @@ async def get_ai_detection(
 
 async def check_draft(
     draft_id: int,
-    token: str,
+    token: str | None = None,
 ) -> dict[str, Any]:
     async with _authenticated_clients(token) as (publication, substack):
         result = await DraftsService(publication, substack).prepublish_draft(draft_id)
@@ -104,7 +104,7 @@ async def check_draft(
 async def schedule_draft(
     draft_id: int,
     scheduled_at: str,
-    token: str,
+    token: str | None = None,
     post_audience: str = "only_paid",
     email_audience: str = "only_paid",
 ) -> dict[str, Any]:
@@ -120,7 +120,7 @@ async def schedule_draft(
 
 async def unschedule_draft(
     draft_id: int,
-    token: str,
+    token: str | None = None,
 ) -> str:
     async with _authenticated_clients(token) as (publication, substack):
         await DraftsService(publication, substack).unschedule_draft(draft_id)
@@ -128,8 +128,8 @@ async def unschedule_draft(
 
 
 async def upload_image(
-    token: str,
     image_base64: str,
+    token: str | None = None,
     content_type: str = "image/png",
 ) -> dict[str, Any]:
     image = data_uri(content_type, base64.b64decode(image_base64))

--- a/packages/gateway_following_mcp/src/gateway_following_mcp/__init__.py
+++ b/packages/gateway_following_mcp/src/gateway_following_mcp/__init__.py
@@ -16,7 +16,7 @@ def _register(mcp: FastMCP) -> None:
     from gateway_following_mcp.tools import get_my_following
 
     mcp.tool(
-        description="Retrieve the list of Substack profiles that the authenticated user follows using an explicit base64-encoded Substack credentials token passed via the tool's token argument.",
+        description="Retrieve the list of Substack profiles that the authenticated user follows. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"me", "following", "read"},
         annotations=ToolAnnotations(
             title="Get My Following",

--- a/packages/gateway_following_mcp/src/gateway_following_mcp/tools.py
+++ b/packages/gateway_following_mcp/src/gateway_following_mcp/tools.py
@@ -7,7 +7,7 @@ from gateway_following.service import FollowingService
 from gateway_mcp_common.clients import _authenticated_clients
 
 
-async def get_my_following(token: str) -> dict[str, Any]:
+async def get_my_following(token: str | None = None) -> dict[str, Any]:
     async with _authenticated_clients(token) as (pub, sub):
         users = await FollowingService(pub, sub).get_own_following()
     return FollowingResponse.from_substack(users).model_dump()

--- a/packages/gateway_mcp_common/pyproject.toml
+++ b/packages/gateway_mcp_common/pyproject.toml
@@ -2,7 +2,7 @@
 name = "gateway_mcp_common"
 version = "3.7.0"
 requires-python = ">=3.11"
-dependencies = ["gateway_core"]
+dependencies = ["gateway_core", "fastmcp>=4.0.2"]
 
 [build-system]
 requires = ["hatchling"]

--- a/packages/gateway_mcp_common/src/gateway_mcp_common/clients.py
+++ b/packages/gateway_mcp_common/src/gateway_mcp_common/clients.py
@@ -10,6 +10,7 @@ from gateway_core.auth import (
     decode_bearer_credentials,
     make_publication_client,
     make_substack_client,
+    validate_bearer_credentials,
 )
 from gateway_core.client.publication import PublicationClient
 from gateway_core.client.substack import SubstackClient
@@ -58,6 +59,7 @@ async def resolve_credentials(token: str | None = None) -> BearerCredentials:
     credentials = await resolver.resolve(get_access_token())
     if credentials is None:
         raise MissingCredentialsError()
+    validate_bearer_credentials(credentials, source="Resolved credentials")
     return credentials
 
 

--- a/packages/gateway_mcp_common/src/gateway_mcp_common/clients.py
+++ b/packages/gateway_mcp_common/src/gateway_mcp_common/clients.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import contextlib
 from collections.abc import AsyncIterator
 
+from fastmcp.server.dependencies import get_access_token
+
 from gateway_core.auth import (
     BearerCredentials,
     decode_bearer_credentials,
@@ -12,6 +14,10 @@ from gateway_core.auth import (
 from gateway_core.client.publication import PublicationClient
 from gateway_core.client.substack import SubstackClient
 from gateway_core.config import settings
+from gateway_core.credentials import (
+    MissingCredentialsError,
+    get_credential_resolver,
+)
 
 
 def _anonymous_credentials() -> BearerCredentials:
@@ -38,11 +44,28 @@ async def _public_publication_client() -> AsyncIterator[PublicationClient]:
         yield publication
 
 
+async def resolve_credentials(token: str | None = None) -> BearerCredentials:
+    """Return the caller's Substack credentials.
+
+    An explicit ``token`` is always preferred. When it is absent, the installed
+    credential resolver is asked about the authenticated caller.
+    """
+    if token:
+        return decode_bearer_credentials(token)
+    resolver = get_credential_resolver()
+    if resolver is None:
+        raise MissingCredentialsError()
+    credentials = await resolver.resolve(get_access_token())
+    if credentials is None:
+        raise MissingCredentialsError()
+    return credentials
+
+
 @contextlib.asynccontextmanager
 async def _authenticated_clients(
-    token: str,
+    token: str | None = None,
 ) -> AsyncIterator[tuple[PublicationClient, SubstackClient]]:
-    credentials = decode_bearer_credentials(token)
+    credentials = await resolve_credentials(token)
     assert credentials.publication_url is not None
     async with (
         make_publication_client(

--- a/packages/gateway_mcp_common/src/gateway_mcp_common/clients.py
+++ b/packages/gateway_mcp_common/src/gateway_mcp_common/clients.py
@@ -62,10 +62,10 @@ async def resolve_credentials(token: str | None = None) -> BearerCredentials:
 
 
 @contextlib.asynccontextmanager
-async def _authenticated_clients(
-    token: str | None = None,
+async def clients_from(
+    credentials: BearerCredentials,
 ) -> AsyncIterator[tuple[PublicationClient, SubstackClient]]:
-    credentials = await resolve_credentials(token)
+    """Yield clients built from credentials that are already resolved."""
     assert credentials.publication_url is not None
     async with (
         make_publication_client(
@@ -74,3 +74,12 @@ async def _authenticated_clients(
         make_substack_client(credentials) as substack,
     ):
         yield publication, substack
+
+
+@contextlib.asynccontextmanager
+async def _authenticated_clients(
+    token: str | None = None,
+) -> AsyncIterator[tuple[PublicationClient, SubstackClient]]:
+    credentials = await resolve_credentials(token)
+    async with clients_from(credentials) as clients:
+        yield clients

--- a/packages/gateway_mcp_common/tests/test_resolve_credentials.py
+++ b/packages/gateway_mcp_common/tests/test_resolve_credentials.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import base64
+import json
+
+import pytest
+
+from gateway_core.auth import BearerCredentials
+from gateway_core.credentials import MissingCredentialsError, set_credential_resolver
+from gateway_mcp_common.clients import resolve_credentials
+
+_EXPLICIT = BearerCredentials(
+    publication_url="https://explicit.substack.com",
+    substack_sid="explicit-sid",
+    connect_sid="explicit-connect",
+)
+_RESOLVED = BearerCredentials(
+    publication_url="https://resolved.substack.com",
+    substack_sid="resolved-sid",
+    connect_sid="resolved-connect",
+)
+
+
+def _encode(credentials: BearerCredentials) -> str:
+    return base64.b64encode(json.dumps(credentials.model_dump()).encode()).decode()
+
+
+class _StubResolver:
+    def __init__(self, credentials: BearerCredentials | None) -> None:
+        self._credentials = credentials
+        self.calls = 0
+
+    async def resolve(self, access_token: object) -> BearerCredentials | None:
+        self.calls += 1
+        return self._credentials
+
+
+@pytest.fixture(autouse=True)
+def _clear_resolver():
+    set_credential_resolver(None)
+    yield
+    set_credential_resolver(None)
+
+
+@pytest.mark.anyio
+async def test_explicit_token_is_decoded() -> None:
+    result = await resolve_credentials(_encode(_EXPLICIT))
+    assert result.publication_url == "https://explicit.substack.com"
+    assert result.substack_sid == "explicit-sid"
+
+
+@pytest.mark.anyio
+async def test_explicit_token_wins_over_resolver() -> None:
+    resolver = _StubResolver(_RESOLVED)
+    set_credential_resolver(resolver)
+    result = await resolve_credentials(_encode(_EXPLICIT))
+    assert result.publication_url == "https://explicit.substack.com"
+    assert resolver.calls == 0
+
+
+@pytest.mark.anyio
+async def test_resolver_used_when_token_omitted() -> None:
+    resolver = _StubResolver(_RESOLVED)
+    set_credential_resolver(resolver)
+    result = await resolve_credentials()
+    assert result.publication_url == "https://resolved.substack.com"
+    assert resolver.calls == 1
+
+
+@pytest.mark.anyio
+async def test_no_resolver_raises() -> None:
+    with pytest.raises(MissingCredentialsError):
+        await resolve_credentials()
+
+
+@pytest.mark.anyio
+async def test_resolver_returning_none_raises() -> None:
+    set_credential_resolver(_StubResolver(None))
+    with pytest.raises(MissingCredentialsError):
+        await resolve_credentials()
+
+
+@pytest.mark.anyio
+async def test_empty_token_string_is_treated_as_omitted() -> None:
+    resolver = _StubResolver(_RESOLVED)
+    set_credential_resolver(resolver)
+    result = await resolve_credentials("")
+    assert result.publication_url == "https://resolved.substack.com"
+    assert resolver.calls == 1

--- a/packages/gateway_me_mcp/src/gateway_me_mcp/__init__.py
+++ b/packages/gateway_me_mcp/src/gateway_me_mcp/__init__.py
@@ -16,7 +16,7 @@ def _register(mcp: FastMCP) -> None:
     from gateway_me_mcp.tools import get_me, get_my_notes, get_my_posts
 
     mcp.tool(
-        description="Retrieve the authenticated user's own Substack public profile using an explicit base64-encoded Substack credentials token passed via the tool's token argument.",
+        description="Retrieve the authenticated user's own Substack public profile. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"me", "profile", "read"},
         annotations=ToolAnnotations(
             title="Get My Profile",
@@ -28,7 +28,7 @@ def _register(mcp: FastMCP) -> None:
         meta={"category": "me", "substack_endpoint": "GET /user/{slug}/public_profile"},
     )(get_me)
     mcp.tool(
-        description="Retrieve the authenticated user's own notes, paginated via an optional cursor. Requires an explicit base64-encoded Substack credentials token passed via the tool's token argument.",
+        description="Retrieve the authenticated user's own notes, paginated via an optional cursor. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"me", "notes", "read"},
         annotations=ToolAnnotations(
             title="Get My Notes",
@@ -40,7 +40,7 @@ def _register(mcp: FastMCP) -> None:
         meta={"category": "me", "substack_endpoint": "GET /notes"},
     )(get_my_notes)
     mcp.tool(
-        description="Retrieve the authenticated user's own posts, paginated via limit and offset. Requires an explicit base64-encoded Substack credentials token passed via the tool's token argument.",
+        description="Retrieve the authenticated user's own posts, paginated via limit and offset. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"me", "posts", "read"},
         annotations=ToolAnnotations(
             title="Get My Posts",

--- a/packages/gateway_me_mcp/src/gateway_me_mcp/tools.py
+++ b/packages/gateway_me_mcp/src/gateway_me_mcp/tools.py
@@ -11,20 +11,22 @@ from gateway_profiles.schemas import ProfileResponse
 from gateway_profiles.service import ProfilesService
 
 
-async def get_me(token: str) -> dict[str, Any]:
+async def get_me(token: str | None = None) -> dict[str, Any]:
     async with _authenticated_clients(token) as (_publication, substack):
         profile = await ProfilesService(substack).get_own_profile()
     return ProfileResponse.from_substack(profile).model_dump()
 
 
-async def get_my_notes(token: str, cursor: str | None = None) -> dict[str, Any]:
+async def get_my_notes(
+    token: str | None = None, cursor: str | None = None
+) -> dict[str, Any]:
     async with _authenticated_clients(token) as (publication, substack):
         page = await NotesService(publication, substack).get_own_notes(cursor=cursor)
     return NotesPageResponse.from_substack(page).model_dump()
 
 
 async def get_my_posts(
-    token: str, limit: int = 25, cursor: str | None = None
+    token: str | None = None, limit: int = 25, cursor: str | None = None
 ) -> dict[str, Any]:
     async with _authenticated_clients(token) as (publication, substack):
         profile = await ProfilesService(substack).get_own_profile()

--- a/packages/gateway_notes_mcp/src/gateway_notes_mcp/__init__.py
+++ b/packages/gateway_notes_mcp/src/gateway_notes_mcp/__init__.py
@@ -32,7 +32,7 @@ def _register(mcp: FastMCP) -> None:
     )
 
     mcp.tool(
-        description="Publish a new note to Substack from Markdown content, with an optional link attachment. Requires an explicit base64-encoded Substack credentials token passed via the tool's token argument.",
+        description="Publish a new note to Substack from Markdown content, with an optional link attachment. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"notes", "write"},
         annotations=ToolAnnotations(
             title="Create Note",
@@ -44,7 +44,7 @@ def _register(mcp: FastMCP) -> None:
         meta={"category": "notes", "substack_endpoint": "POST /comment/feed/"},
     )(create_note)
     mcp.tool(
-        description="Permanently delete a Substack note by its numeric ID. Requires an explicit base64-encoded Substack credentials token passed via the tool's token argument.",
+        description="Permanently delete a Substack note by its numeric ID. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"notes", "write", "delete"},
         annotations=ToolAnnotations(
             title="Delete Note",
@@ -56,7 +56,7 @@ def _register(mcp: FastMCP) -> None:
         meta={"category": "notes", "substack_endpoint": "DELETE /comment/{note_id}"},
     )(delete_note)
     mcp.tool(
-        description="Retrieve a single Substack note by its numeric ID. Requires an explicit base64-encoded Substack credentials token passed via the tool's token argument.",
+        description="Retrieve a single Substack note by its numeric ID. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"notes", "read"},
         annotations=ToolAnnotations(
             title="Get Note",
@@ -71,7 +71,7 @@ def _register(mcp: FastMCP) -> None:
         },
     )(get_note)
     mcp.tool(
-        description="Add a like to a Substack note by its numeric ID. Requires an explicit base64-encoded Substack credentials token passed via the tool's token argument.",
+        description="Add a like to a Substack note by its numeric ID. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"notes", "write"},
         annotations=ToolAnnotations(
             title="Like Note",
@@ -86,7 +86,7 @@ def _register(mcp: FastMCP) -> None:
         },
     )(like_note)
     mcp.tool(
-        description="Remove a like from a Substack note by its numeric ID. Requires an explicit base64-encoded Substack credentials token passed via the tool's token argument.",
+        description="Remove a like from a Substack note by its numeric ID. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"notes", "write"},
         annotations=ToolAnnotations(
             title="Unlike Note",
@@ -101,7 +101,7 @@ def _register(mcp: FastMCP) -> None:
         },
     )(unlike_note)
     mcp.tool(
-        description="Reply to a Substack note or to any comment within its thread, from Markdown content. Requires an explicit base64-encoded Substack credentials token passed via the tool's token argument.",
+        description="Reply to a Substack note or to any comment within its thread, from Markdown content. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"notes", "write"},
         annotations=ToolAnnotations(
             title="Reply To Note",
@@ -113,7 +113,7 @@ def _register(mcp: FastMCP) -> None:
         meta={"category": "notes", "substack_endpoint": "POST /comment/feed/"},
     )(reply_to_note)
     mcp.tool(
-        description="List the direct replies to a Substack note by its numeric ID. Requires an explicit base64-encoded Substack credentials token passed via the tool's token argument.",
+        description="List the direct replies to a Substack note by its numeric ID. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"notes", "read"},
         annotations=ToolAnnotations(
             title="List Note Replies",

--- a/packages/gateway_notes_mcp/src/gateway_notes_mcp/tools.py
+++ b/packages/gateway_notes_mcp/src/gateway_notes_mcp/tools.py
@@ -12,45 +12,47 @@ from gateway_notes.schemas import (
 from gateway_notes.service import NotesService
 
 
-async def get_note(note_id: int, token: str) -> dict[str, Any]:
+async def get_note(note_id: int, token: str | None = None) -> dict[str, Any]:
     async with _authenticated_clients(token) as (pub, sub):
         note = await NotesService(pub, sub).get_note_by_id(note_id)
     return NoteResponse.from_substack(note).model_dump(exclude_none=True)
 
 
 async def create_note(
-    content: str, token: str, attachment: str | None = None
+    content: str, token: str | None = None, attachment: str | None = None
 ) -> dict[str, Any]:
     async with _authenticated_clients(token) as (pub, sub):
         note = await NotesService(pub, sub).create_note(content, attachment=attachment)
     return CreateNoteResponse.from_substack(note).model_dump()
 
 
-async def delete_note(note_id: int, token: str) -> str:
+async def delete_note(note_id: int, token: str | None = None) -> str:
     async with _authenticated_clients(token) as (pub, sub):
         await NotesService(pub, sub).delete_note(note_id)
     return f"Note {note_id} deleted successfully."
 
 
-async def like_note(note_id: int, token: str) -> str:
+async def like_note(note_id: int, token: str | None = None) -> str:
     async with _authenticated_clients(token) as (pub, sub):
         await NotesService(pub, sub).like_note(note_id)
     return f"Note {note_id} liked successfully."
 
 
-async def unlike_note(note_id: int, token: str) -> str:
+async def unlike_note(note_id: int, token: str | None = None) -> str:
     async with _authenticated_clients(token) as (pub, sub):
         await NotesService(pub, sub).unlike_note(note_id)
     return f"Note {note_id} unliked successfully."
 
 
-async def reply_to_note(note_id: int, body: str, token: str) -> dict[str, Any]:
+async def reply_to_note(
+    note_id: int, body: str, token: str | None = None
+) -> dict[str, Any]:
     async with _authenticated_clients(token) as (pub, sub):
         created = await NotesService(pub, sub).reply_to_note(note_id, body)
     return NoteReplyCreatedResponse.from_substack(created).model_dump(exclude_none=True)
 
 
-async def list_note_replies(note_id: int, token: str) -> dict[str, Any]:
+async def list_note_replies(note_id: int, token: str | None = None) -> dict[str, Any]:
     async with _authenticated_clients(token) as (pub, sub):
         replies = await NotesService(pub, sub).list_note_replies(note_id)
     return NoteRepliesResponse.from_substack(replies).model_dump(exclude_none=True)

--- a/packages/gateway_oss/features/mcp/credentials.feature
+++ b/packages/gateway_oss/features/mcp/credentials.feature
@@ -1,0 +1,5 @@
+Feature: MCP credential resolution
+
+  Scenario: A tool called without credentials reports how to supply them
+    When I call the MCP tool get_note without credentials
+    Then the MCP call fails asking for credentials

--- a/packages/gateway_oss/features/steps/mcp_tools.py
+++ b/packages/gateway_oss/features/steps/mcp_tools.py
@@ -22,6 +22,7 @@ from gateway_comments_mcp.tools import (
     reply_to_post_comment,
     unlike_post_comment,
 )
+from gateway_core.credentials import MissingCredentialsError
 from gateway_drafts_mcp.tools import create_draft, delete_draft, get_draft, list_drafts
 from gateway_following_mcp.tools import get_my_following
 from gateway_me_mcp.tools import get_me, get_my_notes, get_my_posts
@@ -119,6 +120,11 @@ def step_call_reply_to_note(context, note_id, body):
 @when("I call the MCP tool list_note_replies with note_id {note_id:d}")
 def step_call_list_note_replies(context, note_id):
     _call(context, list_note_replies(note_id=note_id, token=context.mcp_token))
+
+
+@when("I call the MCP tool get_note without credentials")
+def step_call_get_note_without_credentials(context):
+    _call(context, get_note(note_id=1))
 
 
 # ------------------------------------------------------------------
@@ -345,6 +351,15 @@ def step_mcp_raises_value_error(context):
     assert isinstance(context.mcp_error, ValueError), (
         f"Expected ValueError, got {type(context.mcp_error).__name__}: {context.mcp_error}"
     )
+
+
+@then("the MCP call fails asking for credentials")
+def step_mcp_missing_credentials(context):
+    assert isinstance(context.mcp_error, MissingCredentialsError), (
+        f"Expected MissingCredentialsError, got "
+        f"{type(context.mcp_error).__name__}: {context.mcp_error}"
+    )
+    assert "token" in str(context.mcp_error)
 
 
 @then('the MCP result list "{field}" has {count:d} items')

--- a/packages/gateway_oss/src/gateway_oss/extensions/base.py
+++ b/packages/gateway_oss/src/gateway_oss/extensions/base.py
@@ -9,6 +9,7 @@ from fastapi import FastAPI
 from fastmcp import FastMCP
 from starlette.applications import Starlette
 
+from gateway_core.credentials import CredentialResolver
 from gateway_oss.config import Settings
 
 LifespanHook = Callable[[Any], AbstractAsyncContextManager[None, bool | None]]
@@ -46,6 +47,12 @@ class GatewayExtension(Protocol):
 
     def get_mcp_auth_provider(self, context: GatewayExtensionContext) -> Any | None:
         """Return an MCP auth provider, if the extension exposes one."""
+
+    def get_credential_resolver(
+        self, context: GatewayExtensionContext
+    ) -> CredentialResolver | None:
+        """Return a resolver for MCP callers that omit the token, if any."""
+        return None
 
     def get_module_info(self, context: GatewayExtensionContext) -> ModuleInfo | None:
         """Return this module's metadata for the root endpoint, if any."""

--- a/packages/gateway_oss/tests/test_credential_resolver_wiring.py
+++ b/packages/gateway_oss/tests/test_credential_resolver_wiring.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import pytest
+
+from gateway_core.auth import BearerCredentials
+from gateway_oss.extensions.base import GatewayExtensionContext
+from substack_gateway.runtime import _single_provider
+
+
+class _Resolver:
+    async def resolve(self, access_token: object) -> BearerCredentials | None:
+        return None
+
+
+class _ExtensionWithResolver:
+    name = "with-resolver"
+
+    def __init__(self, resolver: object) -> None:
+        self._resolver = resolver
+
+    def get_credential_resolver(self, context: GatewayExtensionContext) -> object:
+        return self._resolver
+
+
+def test_single_provider_returns_the_only_resolver() -> None:
+    resolver = _Resolver()
+    assert _single_provider("credential resolver", [None, resolver]) is resolver
+
+
+def test_single_provider_returns_none_when_no_extension_supplies_one() -> None:
+    assert _single_provider("credential resolver", [None, None]) is None
+
+
+def test_two_resolvers_is_a_startup_error() -> None:
+    with pytest.raises(RuntimeError, match="credential resolver"):
+        _single_provider("credential resolver", [_Resolver(), _Resolver()])
+
+
+def test_protocol_default_returns_none() -> None:
+    from gateway_oss.extensions.base import GatewayExtension
+
+    class _Bare(GatewayExtension):
+        name = "bare"
+
+    context = GatewayExtensionContext(settings=None)  # ty: ignore[invalid-argument-type]
+    assert _Bare().get_credential_resolver(context) is None

--- a/packages/gateway_oss/tests/test_credential_resolver_wiring.py
+++ b/packages/gateway_oss/tests/test_credential_resolver_wiring.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 import pytest
 
 from gateway_core.auth import BearerCredentials
-from gateway_oss.extensions.base import GatewayExtensionContext
-from substack_gateway.runtime import _single_provider
+from gateway_core.credentials import get_credential_resolver, set_credential_resolver
+from gateway_oss.extensions.base import GatewayExtensionContext, ModuleInfo
+from substack_gateway import runtime
+from substack_gateway.runtime import LifespanHook, _single_provider, get_runtime
 
 
 class _Resolver:
@@ -20,6 +24,14 @@ class _ExtensionWithResolver:
 
     def get_credential_resolver(self, context: GatewayExtensionContext) -> object:
         return self._resolver
+
+    def get_lifespan_hooks(
+        self, context: GatewayExtensionContext
+    ) -> Sequence[LifespanHook]:
+        return []
+
+    def get_module_info(self, context: GatewayExtensionContext) -> ModuleInfo | None:
+        return None
 
 
 def test_single_provider_returns_the_only_resolver() -> None:
@@ -44,3 +56,29 @@ def test_protocol_default_returns_none() -> None:
 
     context = GatewayExtensionContext(settings=None)  # ty: ignore[invalid-argument-type]
     assert _Bare().get_credential_resolver(context) is None
+
+
+@pytest.fixture(autouse=True)
+def _clear_resolver():
+    set_credential_resolver(None)
+    get_runtime.cache_clear()
+    yield
+    get_runtime.cache_clear()
+    set_credential_resolver(None)
+
+
+def test_extension_resolver_is_wired_into_gateway_core(monkeypatch) -> None:
+    """The one link spanning the shell, gateway_oss, and gateway_core.
+
+    An extension's `get_credential_resolver` result must end up installed as
+    the process-wide resolver that `gateway_core.get_credential_resolver()`
+    returns, not just be reachable in isolation via `_single_provider`.
+    """
+    resolver = _Resolver()
+    extension = _ExtensionWithResolver(resolver)
+    monkeypatch.setattr(runtime, "load_extensions", lambda: [extension])
+
+    get_runtime.cache_clear()
+    get_runtime()
+
+    assert get_credential_resolver() is resolver

--- a/packages/gateway_posts_mcp/src/gateway_posts_mcp/__init__.py
+++ b/packages/gateway_posts_mcp/src/gateway_posts_mcp/__init__.py
@@ -21,7 +21,7 @@ def _register(mcp: FastMCP) -> None:
     from gateway_posts_mcp.tools import get_post, like_post, restack_post, unlike_post
 
     mcp.tool(
-        description="Retrieve the full content of a Substack post by its numeric ID. Requires an explicit base64-encoded Substack credentials token passed via the tool's token argument.",
+        description="Retrieve the full content of a Substack post by its numeric ID. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"posts", "read"},
         annotations=ToolAnnotations(
             title="Get Post",
@@ -33,7 +33,7 @@ def _register(mcp: FastMCP) -> None:
         meta={"category": "posts", "substack_endpoint": "GET /posts/by-id/{post_id}"},
     )(get_post)
     mcp.tool(
-        description="Add a heart like to a Substack post by its numeric ID. Requires an explicit base64-encoded Substack credentials token passed via the tool's token argument.",
+        description="Add a heart like to a Substack post by its numeric ID. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"posts", "write"},
         annotations=ToolAnnotations(
             title="Like Post",
@@ -48,7 +48,7 @@ def _register(mcp: FastMCP) -> None:
         },
     )(like_post)
     mcp.tool(
-        description="Remove a heart like from a Substack post by its numeric ID. Requires an explicit base64-encoded Substack credentials token passed via the tool's token argument.",
+        description="Remove a heart like from a Substack post by its numeric ID. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"posts", "write", "delete"},
         annotations=ToolAnnotations(
             title="Unlike Post",
@@ -63,7 +63,7 @@ def _register(mcp: FastMCP) -> None:
         },
     )(unlike_post)
     mcp.tool(
-        description="Restack a Substack post into the authenticated user's feed by its numeric ID. Requires an explicit base64-encoded Substack credentials token passed via the tool's token argument.",
+        description="Restack a Substack post into the authenticated user's feed by its numeric ID. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"posts", "write"},
         annotations=ToolAnnotations(
             title="Restack Post",

--- a/packages/gateway_posts_mcp/src/gateway_posts_mcp/tools.py
+++ b/packages/gateway_posts_mcp/src/gateway_posts_mcp/tools.py
@@ -11,25 +11,25 @@ from gateway_posts.service import (
 )
 
 
-async def get_post(post_id: int, token: str) -> dict[str, Any]:
+async def get_post(post_id: int, token: str | None = None) -> dict[str, Any]:
     async with _authenticated_clients(token) as (pub, sub):
         post = await PostsService(pub, sub).get_post_by_id(post_id)
     return FullPostResponse.from_substack(post).model_dump()
 
 
-async def like_post(post_id: int, token: str) -> str:
+async def like_post(post_id: int, token: str | None = None) -> str:
     async with _authenticated_clients(token) as (_pub, sub):
         await PostReactionsService(sub).like_post(post_id)
     return f"Post {post_id} liked successfully."
 
 
-async def unlike_post(post_id: int, token: str) -> str:
+async def unlike_post(post_id: int, token: str | None = None) -> str:
     async with _authenticated_clients(token) as (_pub, sub):
         await PostReactionsService(sub).unlike_post(post_id)
     return f"Post {post_id} unliked successfully."
 
 
-async def restack_post(post_id: int, token: str) -> str:
+async def restack_post(post_id: int, token: str | None = None) -> str:
     async with _authenticated_clients(token) as (_pub, sub):
         await PostRestacksService(sub).restack_post(post_id)
     return f"Post {post_id} restacked successfully."

--- a/packages/gateway_stats_mcp/src/gateway_stats_mcp/__init__.py
+++ b/packages/gateway_stats_mcp/src/gateway_stats_mcp/__init__.py
@@ -32,7 +32,7 @@ def _register(mcp: FastMCP) -> None:
     )
 
     mcp.tool(
-        description="Fetch the publication's daily subscriber timeseries (paid, comps, free trials, total) for the trailing year. Optionally pass `from_date` (ISO) to bound the window. Results are delta-cached: repeat calls only fetch new days from Substack. Requires an explicit base64-encoded Substack credentials token passed via the tool's token argument.",
+        description="Fetch the publication's daily subscriber timeseries (paid, comps, free trials, total) for the trailing year. Optionally pass `from_date` (ISO) to bound the window. Results are delta-cached: repeat calls only fetch new days from Substack. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"stats", "read"},
         annotations=ToolAnnotations(
             title="Get Subscriber Timeseries",
@@ -47,7 +47,7 @@ def _register(mcp: FastMCP) -> None:
         },
     )(get_subscriber_timeseries)
     mcp.tool(
-        description="Fetch the publication's trailing-30-day view count and its delta versus the prior period. Result is a short-lived cached snapshot. Requires an explicit base64-encoded Substack credentials token passed via the tool's token argument.",
+        description="Fetch the publication's trailing-30-day view count and its delta versus the prior period. Result is a short-lived cached snapshot. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"stats", "read"},
         annotations=ToolAnnotations(
             title="Get 30-Day Views",
@@ -64,7 +64,7 @@ def _register(mcp: FastMCP) -> None:
         },
     )(get_30d_views)
     mcp.tool(
-        description="Fetch engagement for a published post: like count and likers, comment count and summary, and commenter count. Result is a short-lived cached snapshot. Requires an explicit base64-encoded Substack credentials token passed via the tool's token argument.",
+        description="Fetch engagement for a published post: like count and likers, comment count and summary, and commenter count. Result is a short-lived cached snapshot. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"post-stats", "read"},
         annotations=ToolAnnotations(
             title="Get Post Engagement",
@@ -79,7 +79,7 @@ def _register(mcp: FastMCP) -> None:
         },
     )(get_post_engagement)
     mcp.tool(
-        description="Fetch traffic for a published post: view counts broken down by referrer source, device type, and category. Result is a short-lived cached snapshot. Requires an explicit base64-encoded Substack credentials token passed via the tool's token argument.",
+        description="Fetch traffic for a published post: view counts broken down by referrer source, device type, and category. Result is a short-lived cached snapshot. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"post-stats", "read"},
         annotations=ToolAnnotations(
             title="Get Post Traffic",
@@ -94,7 +94,7 @@ def _register(mcp: FastMCP) -> None:
         },
     )(get_post_traffic)
     mcp.tool(
-        description="Fetch per-recipient email stats for a published post (delivery, opens, clicks), paginated via limit/offset. Result is a short-lived cached snapshot. Requires an explicit base64-encoded Substack credentials token passed via the tool's token argument.",
+        description="Fetch per-recipient email stats for a published post (delivery, opens, clicks), paginated via limit/offset. Result is a short-lived cached snapshot. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"post-stats", "read"},
         annotations=ToolAnnotations(
             title="Get Post Recipients",
@@ -109,7 +109,7 @@ def _register(mcp: FastMCP) -> None:
         },
     )(get_post_recipients)
     mcp.tool(
-        description="Fetch subscriber growth attributed to a published post. Result is a short-lived cached snapshot. Requires an explicit base64-encoded Substack credentials token passed via the tool's token argument.",
+        description="Fetch subscriber growth attributed to a published post. Result is a short-lived cached snapshot. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"post-stats", "read"},
         annotations=ToolAnnotations(
             title="Get Post Growth",
@@ -124,7 +124,7 @@ def _register(mcp: FastMCP) -> None:
         },
     )(get_post_growth)
     mcp.tool(
-        description="Fetch the discussion (comment thread) for a published post, cursor-paginated. Result is a short-lived cached snapshot. Requires an explicit base64-encoded Substack credentials token passed via the tool's token argument.",
+        description="Fetch the discussion (comment thread) for a published post, cursor-paginated. Result is a short-lived cached snapshot. The `token` argument is optional: pass base64-encoded Substack credentials, or omit it if this deployment resolves credentials from the authenticated session.",
         tags={"post-stats", "read"},
         annotations=ToolAnnotations(
             title="Get Post Discussion",

--- a/packages/gateway_stats_mcp/src/gateway_stats_mcp/tools.py
+++ b/packages/gateway_stats_mcp/src/gateway_stats_mcp/tools.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from gateway_mcp_common.clients import _authenticated_clients, resolve_credentials
+from gateway_core.auth import BearerCredentials
+from gateway_mcp_common.clients import clients_from, resolve_credentials
 from gateway_stats.cache import create_stats_cache
 from gateway_stats.post_stats import PostStatsService
 from gateway_stats.schemas import (
@@ -23,7 +24,7 @@ async def get_subscriber_timeseries(
 ) -> dict[str, Any]:
     credentials = await resolve_credentials(token)
     assert credentials.publication_url is not None
-    async with _authenticated_clients(token) as (publication, substack):
+    async with clients_from(credentials) as (publication, substack):
         rows = await StatsService(
             publication, substack, create_stats_cache(), credentials.publication_url
         ).subscriber_timeseries(from_=from_date)
@@ -35,15 +36,16 @@ async def get_30d_views(
 ) -> dict[str, Any]:
     credentials = await resolve_credentials(token)
     assert credentials.publication_url is not None
-    async with _authenticated_clients(token) as (publication, substack):
+    async with clients_from(credentials) as (publication, substack):
         data = await StatsService(
             publication, substack, create_stats_cache(), credentials.publication_url
         ).thirty_day_views()
     return ThirtyDayViewsResponse.from_substack(data).model_dump()
 
 
-async def _post_stats_service(token, publication, substack) -> PostStatsService:
-    credentials = await resolve_credentials(token)
+def _post_stats_service(
+    credentials: BearerCredentials, publication, substack
+) -> PostStatsService:
     assert credentials.publication_url is not None
     return PostStatsService(
         publication, substack, create_stats_cache(), credentials.publication_url
@@ -51,16 +53,18 @@ async def _post_stats_service(token, publication, substack) -> PostStatsService:
 
 
 async def get_post_engagement(post_id: int, token: str | None = None) -> dict[str, Any]:
-    async with _authenticated_clients(token) as (publication, substack):
-        data = await (
-            await _post_stats_service(token, publication, substack)
-        ).engagement(post_id)
+    credentials = await resolve_credentials(token)
+    async with clients_from(credentials) as (publication, substack):
+        data = await _post_stats_service(credentials, publication, substack).engagement(
+            post_id
+        )
     return PostEngagementResponse.from_substack(data).model_dump()
 
 
 async def get_post_traffic(post_id: int, token: str | None = None) -> dict[str, Any]:
-    async with _authenticated_clients(token) as (publication, substack):
-        data = await (await _post_stats_service(token, publication, substack)).traffic(
+    credentials = await resolve_credentials(token)
+    async with clients_from(credentials) as (publication, substack):
+        data = await _post_stats_service(credentials, publication, substack).traffic(
             post_id
         )
     return PostTrafficResponse.from_substack(data).model_dump()
@@ -72,16 +76,18 @@ async def get_post_recipients(
     limit: int = 20,
     offset: int = 0,
 ) -> dict[str, Any]:
-    async with _authenticated_clients(token) as (publication, substack):
-        data = await (
-            await _post_stats_service(token, publication, substack)
-        ).recipients(post_id, limit=limit, offset=offset)
+    credentials = await resolve_credentials(token)
+    async with clients_from(credentials) as (publication, substack):
+        data = await _post_stats_service(credentials, publication, substack).recipients(
+            post_id, limit=limit, offset=offset
+        )
     return PostRecipientsResponse.from_substack(data).model_dump()
 
 
 async def get_post_growth(post_id: int, token: str | None = None) -> dict[str, Any]:
-    async with _authenticated_clients(token) as (publication, substack):
-        data = await (await _post_stats_service(token, publication, substack)).growth(
+    credentials = await resolve_credentials(token)
+    async with clients_from(credentials) as (publication, substack):
+        data = await _post_stats_service(credentials, publication, substack).growth(
             post_id
         )
     return PostGrowthResponse.from_substack(data).model_dump()
@@ -92,8 +98,9 @@ async def get_post_discussion(
     token: str | None = None,
     cursor: str | None = None,
 ) -> dict[str, Any]:
-    async with _authenticated_clients(token) as (publication, substack):
-        data = await (
-            await _post_stats_service(token, publication, substack)
-        ).discussion(post_id, cursor=cursor)
+    credentials = await resolve_credentials(token)
+    async with clients_from(credentials) as (publication, substack):
+        data = await _post_stats_service(credentials, publication, substack).discussion(
+            post_id, cursor=cursor
+        )
     return PostDiscussionResponse.from_substack(data).model_dump()

--- a/packages/gateway_stats_mcp/src/gateway_stats_mcp/tools.py
+++ b/packages/gateway_stats_mcp/src/gateway_stats_mcp/tools.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from gateway_core.auth import decode_bearer_credentials
-from gateway_mcp_common.clients import _authenticated_clients
+from gateway_mcp_common.clients import _authenticated_clients, resolve_credentials
 from gateway_stats.cache import create_stats_cache
 from gateway_stats.post_stats import PostStatsService
 from gateway_stats.schemas import (
@@ -19,10 +18,10 @@ from gateway_stats.service import StatsService
 
 
 async def get_subscriber_timeseries(
-    token: str,
+    token: str | None = None,
     from_date: str | None = None,
 ) -> dict[str, Any]:
-    credentials = decode_bearer_credentials(token)
+    credentials = await resolve_credentials(token)
     assert credentials.publication_url is not None
     async with _authenticated_clients(token) as (publication, substack):
         rows = await StatsService(
@@ -32,9 +31,9 @@ async def get_subscriber_timeseries(
 
 
 async def get_30d_views(
-    token: str,
+    token: str | None = None,
 ) -> dict[str, Any]:
-    credentials = decode_bearer_credentials(token)
+    credentials = await resolve_credentials(token)
     assert credentials.publication_url is not None
     async with _authenticated_clients(token) as (publication, substack):
         data = await StatsService(
@@ -43,54 +42,58 @@ async def get_30d_views(
     return ThirtyDayViewsResponse.from_substack(data).model_dump()
 
 
-def _post_stats_service(token, publication, substack) -> PostStatsService:
-    credentials = decode_bearer_credentials(token)
+async def _post_stats_service(token, publication, substack) -> PostStatsService:
+    credentials = await resolve_credentials(token)
     assert credentials.publication_url is not None
     return PostStatsService(
         publication, substack, create_stats_cache(), credentials.publication_url
     )
 
 
-async def get_post_engagement(post_id: int, token: str) -> dict[str, Any]:
+async def get_post_engagement(post_id: int, token: str | None = None) -> dict[str, Any]:
     async with _authenticated_clients(token) as (publication, substack):
-        data = await _post_stats_service(token, publication, substack).engagement(
-            post_id
-        )
+        data = await (
+            await _post_stats_service(token, publication, substack)
+        ).engagement(post_id)
     return PostEngagementResponse.from_substack(data).model_dump()
 
 
-async def get_post_traffic(post_id: int, token: str) -> dict[str, Any]:
+async def get_post_traffic(post_id: int, token: str | None = None) -> dict[str, Any]:
     async with _authenticated_clients(token) as (publication, substack):
-        data = await _post_stats_service(token, publication, substack).traffic(post_id)
+        data = await (await _post_stats_service(token, publication, substack)).traffic(
+            post_id
+        )
     return PostTrafficResponse.from_substack(data).model_dump()
 
 
 async def get_post_recipients(
     post_id: int,
-    token: str,
+    token: str | None = None,
     limit: int = 20,
     offset: int = 0,
 ) -> dict[str, Any]:
     async with _authenticated_clients(token) as (publication, substack):
-        data = await _post_stats_service(token, publication, substack).recipients(
-            post_id, limit=limit, offset=offset
-        )
+        data = await (
+            await _post_stats_service(token, publication, substack)
+        ).recipients(post_id, limit=limit, offset=offset)
     return PostRecipientsResponse.from_substack(data).model_dump()
 
 
-async def get_post_growth(post_id: int, token: str) -> dict[str, Any]:
+async def get_post_growth(post_id: int, token: str | None = None) -> dict[str, Any]:
     async with _authenticated_clients(token) as (publication, substack):
-        data = await _post_stats_service(token, publication, substack).growth(post_id)
+        data = await (await _post_stats_service(token, publication, substack)).growth(
+            post_id
+        )
     return PostGrowthResponse.from_substack(data).model_dump()
 
 
 async def get_post_discussion(
     post_id: int,
-    token: str,
+    token: str | None = None,
     cursor: str | None = None,
 ) -> dict[str, Any]:
     async with _authenticated_clients(token) as (publication, substack):
-        data = await _post_stats_service(token, publication, substack).discussion(
-            post_id, cursor=cursor
-        )
+        data = await (
+            await _post_stats_service(token, publication, substack)
+        ).discussion(post_id, cursor=cursor)
     return PostDiscussionResponse.from_substack(data).model_dump()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ testpaths = [
   "packages/gateway_profiles/tests",
   "packages/gateway_stats/tests",
   "packages/gateway_drafts/tests",
+  "packages/gateway_mcp_common/tests",
 ]
 addopts = "--import-mode=importlib"
 

--- a/src/substack_gateway/runtime.py
+++ b/src/substack_gateway/runtime.py
@@ -35,6 +35,22 @@ def _single_provider(label: str, providers: Sequence[T | None]) -> T | None:
     return active[0] if active else None
 
 
+def _call_optional_hook(
+    extension: GatewayExtension, method_name: str, context: GatewayExtensionContext
+) -> Any | None:
+    """Call an optional protocol method, tolerating extensions that don't define it.
+
+    `ext_loader.load_extensions` never checks a loaded extension against the
+    `GatewayExtension` protocol, so a duck-typed extension that doesn't subclass it
+    may lack methods the protocol declares with a default. Fall back to `None`
+    rather than raising `AttributeError` for those.
+    """
+    method = getattr(extension, method_name, None)
+    if method is None:
+        return None
+    return method(context)
+
+
 @lru_cache(maxsize=1)
 def get_runtime() -> GatewayRuntime:
     context = GatewayExtensionContext(settings=settings)
@@ -46,11 +62,17 @@ def get_runtime() -> GatewayRuntime:
     ]
     mcp_auth_provider = _single_provider(
         "MCP auth provider",
-        [extension.get_mcp_auth_provider(context) for extension in extensions],
+        [
+            _call_optional_hook(extension, "get_mcp_auth_provider", context)
+            for extension in extensions
+        ],
     )
     credential_resolver = _single_provider(
         "credential resolver",
-        [extension.get_credential_resolver(context) for extension in extensions],
+        [
+            _call_optional_hook(extension, "get_credential_resolver", context)
+            for extension in extensions
+        ],
     )
     set_credential_resolver(credential_resolver)
     module_infos = [

--- a/src/substack_gateway/runtime.py
+++ b/src/substack_gateway/runtime.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from functools import lru_cache
 from typing import Any, TypeVar
 
+from gateway_core.credentials import CredentialResolver, set_credential_resolver
 from gateway_oss.config import settings
 from gateway_oss.extensions.base import (
     GatewayExtension,
@@ -23,6 +24,7 @@ class GatewayRuntime:
     extensions: list[GatewayExtension]
     lifespan_hooks: list[LifespanHook]
     mcp_auth_provider: Any | None
+    credential_resolver: CredentialResolver | None
     module_infos: list[ModuleInfo]
 
 
@@ -46,6 +48,11 @@ def get_runtime() -> GatewayRuntime:
         "MCP auth provider",
         [extension.get_mcp_auth_provider(context) for extension in extensions],
     )
+    credential_resolver = _single_provider(
+        "credential resolver",
+        [extension.get_credential_resolver(context) for extension in extensions],
+    )
+    set_credential_resolver(credential_resolver)
     module_infos = [
         info
         for extension in extensions
@@ -56,5 +63,6 @@ def get_runtime() -> GatewayRuntime:
         extensions=extensions,
         lifespan_hooks=lifespan_hooks,
         mcp_auth_provider=mcp_auth_provider,
+        credential_resolver=credential_resolver,
         module_infos=module_infos,
     )

--- a/uv.lock
+++ b/uv.lock
@@ -536,7 +536,7 @@ server = [
 
 [[package]]
 name = "gateway-comments"
-version = "3.6.0"
+version = "3.7.0"
 source = { editable = "packages/gateway_comments" }
 dependencies = [
     { name = "gateway-core" },
@@ -553,7 +553,7 @@ requires-dist = [
 
 [[package]]
 name = "gateway-comments-mcp"
-version = "3.6.0"
+version = "3.7.0"
 source = { editable = "packages/gateway_comments_mcp" }
 dependencies = [
     { name = "fastmcp" },
@@ -572,7 +572,7 @@ requires-dist = [
 
 [[package]]
 name = "gateway-comments-rest"
-version = "3.6.0"
+version = "3.7.0"
 source = { editable = "packages/gateway_comments_rest" }
 dependencies = [
     { name = "fastapi" },
@@ -593,7 +593,7 @@ requires-dist = [
 
 [[package]]
 name = "gateway-core"
-version = "3.6.0"
+version = "3.7.0"
 source = { editable = "packages/gateway_core" }
 dependencies = [
     { name = "aiocache", extra = ["redis"] },
@@ -618,7 +618,7 @@ requires-dist = [
 
 [[package]]
 name = "gateway-drafts"
-version = "3.6.0"
+version = "3.7.0"
 source = { editable = "packages/gateway_drafts" }
 dependencies = [
     { name = "gateway-core" },
@@ -633,7 +633,7 @@ requires-dist = [
 
 [[package]]
 name = "gateway-drafts-mcp"
-version = "3.6.0"
+version = "3.7.0"
 source = { editable = "packages/gateway_drafts_mcp" }
 dependencies = [
     { name = "fastmcp" },
@@ -652,7 +652,7 @@ requires-dist = [
 
 [[package]]
 name = "gateway-drafts-rest"
-version = "3.6.0"
+version = "3.7.0"
 source = { editable = "packages/gateway_drafts_rest" }
 dependencies = [
     { name = "fastapi" },
@@ -673,7 +673,7 @@ requires-dist = [
 
 [[package]]
 name = "gateway-following"
-version = "3.6.0"
+version = "3.7.0"
 source = { editable = "packages/gateway_following" }
 dependencies = [
     { name = "gateway-core" },
@@ -688,7 +688,7 @@ requires-dist = [
 
 [[package]]
 name = "gateway-following-mcp"
-version = "3.6.0"
+version = "3.7.0"
 source = { editable = "packages/gateway_following_mcp" }
 dependencies = [
     { name = "fastmcp" },
@@ -707,7 +707,7 @@ requires-dist = [
 
 [[package]]
 name = "gateway-following-rest"
-version = "3.6.0"
+version = "3.7.0"
 source = { editable = "packages/gateway_following_rest" }
 dependencies = [
     { name = "fastapi" },
@@ -726,18 +726,22 @@ requires-dist = [
 
 [[package]]
 name = "gateway-mcp-common"
-version = "3.6.0"
+version = "3.7.0"
 source = { editable = "packages/gateway_mcp_common" }
 dependencies = [
+    { name = "fastmcp" },
     { name = "gateway-core" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "gateway-core", editable = "packages/gateway_core" }]
+requires-dist = [
+    { name = "fastmcp", specifier = ">=4.0.2" },
+    { name = "gateway-core", editable = "packages/gateway_core" },
+]
 
 [[package]]
 name = "gateway-me-mcp"
-version = "3.6.0"
+version = "3.7.0"
 source = { editable = "packages/gateway_me_mcp" }
 dependencies = [
     { name = "fastmcp" },
@@ -760,7 +764,7 @@ requires-dist = [
 
 [[package]]
 name = "gateway-me-rest"
-version = "3.6.0"
+version = "3.7.0"
 source = { editable = "packages/gateway_me_rest" }
 dependencies = [
     { name = "fastapi" },
@@ -783,7 +787,7 @@ requires-dist = [
 
 [[package]]
 name = "gateway-notes"
-version = "3.6.0"
+version = "3.7.0"
 source = { editable = "packages/gateway_notes" }
 dependencies = [
     { name = "gateway-core" },
@@ -798,7 +802,7 @@ requires-dist = [
 
 [[package]]
 name = "gateway-notes-mcp"
-version = "3.6.0"
+version = "3.7.0"
 source = { editable = "packages/gateway_notes_mcp" }
 dependencies = [
     { name = "fastmcp" },
@@ -817,7 +821,7 @@ requires-dist = [
 
 [[package]]
 name = "gateway-notes-rest"
-version = "3.6.0"
+version = "3.7.0"
 source = { editable = "packages/gateway_notes_rest" }
 dependencies = [
     { name = "fastapi" },
@@ -836,7 +840,7 @@ requires-dist = [
 
 [[package]]
 name = "gateway-oss"
-version = "3.6.0"
+version = "3.7.0"
 source = { editable = "packages/gateway_oss" }
 dependencies = [
     { name = "aiocache", extra = ["redis"] },
@@ -919,7 +923,7 @@ requires-dist = [
 
 [[package]]
 name = "gateway-posts"
-version = "3.6.0"
+version = "3.7.0"
 source = { editable = "packages/gateway_posts" }
 dependencies = [
     { name = "gateway-core" },
@@ -934,7 +938,7 @@ requires-dist = [
 
 [[package]]
 name = "gateway-posts-mcp"
-version = "3.6.0"
+version = "3.7.0"
 source = { editable = "packages/gateway_posts_mcp" }
 dependencies = [
     { name = "fastmcp" },
@@ -953,7 +957,7 @@ requires-dist = [
 
 [[package]]
 name = "gateway-posts-rest"
-version = "3.6.0"
+version = "3.7.0"
 source = { editable = "packages/gateway_posts_rest" }
 dependencies = [
     { name = "fastapi" },
@@ -972,7 +976,7 @@ requires-dist = [
 
 [[package]]
 name = "gateway-profiles"
-version = "3.6.0"
+version = "3.7.0"
 source = { editable = "packages/gateway_profiles" }
 dependencies = [
     { name = "aiocache", extra = ["redis"] },
@@ -989,7 +993,7 @@ requires-dist = [
 
 [[package]]
 name = "gateway-profiles-mcp"
-version = "3.6.0"
+version = "3.7.0"
 source = { editable = "packages/gateway_profiles_mcp" }
 dependencies = [
     { name = "fastmcp" },
@@ -1012,7 +1016,7 @@ requires-dist = [
 
 [[package]]
 name = "gateway-profiles-rest"
-version = "3.6.0"
+version = "3.7.0"
 source = { editable = "packages/gateway_profiles_rest" }
 dependencies = [
     { name = "fastapi" },
@@ -1035,7 +1039,7 @@ requires-dist = [
 
 [[package]]
 name = "gateway-rest-common"
-version = "3.6.0"
+version = "3.7.0"
 source = { editable = "packages/gateway_rest_common" }
 dependencies = [
     { name = "fastapi" },
@@ -1050,7 +1054,7 @@ requires-dist = [
 
 [[package]]
 name = "gateway-stats"
-version = "3.6.0"
+version = "3.7.0"
 source = { editable = "packages/gateway_stats" }
 dependencies = [
     { name = "gateway-core" },
@@ -1067,7 +1071,7 @@ requires-dist = [
 
 [[package]]
 name = "gateway-stats-mcp"
-version = "3.6.0"
+version = "3.7.0"
 source = { editable = "packages/gateway_stats_mcp" }
 dependencies = [
     { name = "fastmcp" },
@@ -1086,7 +1090,7 @@ requires-dist = [
 
 [[package]]
 name = "gateway-stats-rest"
-version = "3.6.0"
+version = "3.7.0"
 source = { editable = "packages/gateway_stats_rest" }
 dependencies = [
     { name = "fastapi" },
@@ -1139,8 +1143,8 @@ name = "httpcore2"
 version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "h11" },
-    { name = "truststore" },
+    { name = "h11", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
+    { name = "truststore", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
 wheels = [
@@ -2037,8 +2041,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "(python_full_version < '3.12' and sys_platform == 'emscripten') or (python_full_version >= '3.14' and sys_platform == 'emscripten') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "jeepney", marker = "(python_full_version < '3.12' and sys_platform == 'emscripten') or (python_full_version >= '3.14' and sys_platform == 'emscripten') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
Makes the `token` argument optional on every authenticated MCP tool, and adds a seam through which a deployment can resolve Substack credentials from the authenticated session instead of receiving them on each call.

Standalone behaviour is unchanged: this repository installs no resolver, so a tool called without a token raises an error that says how to supply one.

## How a call resolves now

| Call | Behaviour |
|---|---|
| `token` supplied | Decoded exactly as before. The resolver is never consulted. |
| `token` omitted, resolver installed | The resolver maps the authenticated caller to credentials. |
| `token` omitted, no resolver | `MissingCredentialsError`, whose message tells the caller to pass `token`. |

Every existing caller keeps working — an explicit token always wins, and short-circuits before any resolver lookup.

## What was added

- **`gateway_core.credentials`** — a `CredentialResolver` protocol, a process-wide registry, and `MissingCredentialsError`. The protocol types its argument loosely and names the concrete type in prose, so `gateway_core` stays free of a FastMCP dependency; it is used by the REST layer too.
- **`gateway_mcp_common.clients.resolve_credentials(token=None)`** — the single branch described in the table above, and `clients_from(credentials)` for callers that already hold resolved credentials. `_authenticated_clients` is written in terms of both, so all 40 tools share one implementation.
- **`GatewayExtension.get_credential_resolver`** — a single-provider slot alongside the existing MCP auth provider one. Two extensions offering a resolver is a startup error, not a silent last-wins. The shell selects and installs it at startup.

Credentials returned by a resolver are validated exactly as a decoded token is — `publication_url` present and a real HTTP(S) URL, both cookies non-empty — so a resolver backed by a datastore cannot feed partially-populated credentials into outbound requests. The check is shared with the token path rather than duplicated.

## What does not change

- The REST layer. `x-gateway-token` stays required; there is no session identity to resolve from there.
- The three public profile tools, which take no credentials at all.
- `decode_bearer_credentials` and its validation rules, including its exact error messages.
- Any client that passes a token.

## The tradeoff, stated plainly

`token` leaving the schema's required list means a model client talking to a deployment with no resolver can omit it and get a runtime error where it previously got a schema error. Mitigated by the error message and by every tool description now saying the argument is optional and when to supply it. This is a real ergonomic cost for the standalone case, accepted so the resolver case is possible at all.

## Note on `uv.lock`

Larger than one added dependency would explain. Besides declaring `fastmcp` on `gateway_mcp_common`, the relock picked up a pending version sync: the committed lock recorded every workspace member as `3.6.0` while the manifests said `3.7.0` — the last release bumped the manifests without regenerating the lock. No third-party version moved.

## Validation

`ruff check`, `ruff format --check`, `ty check` (exit 0), `uv build --all-packages`, `pytest` 148 passed / 1 skipped, `behave` 33 features / 228 scenarios / 1004 steps.

The behave suite covers the no-credentials path end to end; unit tests pin that an explicit token is preferred over an installed resolver, that both missing-credential branches raise, and that an extension's resolver reaches the registry through the shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011dacfYpWEMVtmrWZ8BaCuG
